### PR TITLE
If a session isn't in the DB, don't error when destroying.

### DIFF
--- a/lib/connect-session-sequelize.js
+++ b/lib/connect-session-sequelize.js
@@ -85,7 +85,7 @@ module.exports = function SequelizeSessionInit(connect) {
 	SequelizeStore.prototype.destroy = function destroySession(sid, fn) {
 		debug('DESTROYING %s', sid);
 		this.sessionModel.find({where: {'sid': sid}}).success(function foundSession(session) {
-			// If the session wasn't found, then consider it destroyeda already.
+			// If the session wasn't found, then consider it destroyed already.
 			if (session === null) {
 				debug('Session not found, assuming destroyed %s', sid);
 				fn();


### PR DESCRIPTION
When destroying a session, if that session doesn't exist in the database, then Sequelize will return a null from the .find, indicating that the find executed normally, but didn't find anything.

Currently this throws an exception.

We can probably just assume that the session has been destroyed, because it's not in the DB any more, and pretend like the destroy succeeded.
