### PR TITLE
Support Express 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ $ npm install connect-session-sequelize
 
 ```javascript
 var connect = require('connect')
-	// for express, just call it with 'express'
-	, SequelizeStore = require('connect-session-sequelize')(connect);
+	// for express, just call it with 'require('express-session').Store'
+	, SequelizeStore = require('connect-session-sequelize')(connect.session.Store);
 
 connect().use(connect.session({
 	store: new SequelizeStore(options)

--- a/lib/connect-session-sequelize.js
+++ b/lib/connect-session-sequelize.js
@@ -17,9 +17,7 @@ function SequelizeStoreException(message) {
 }
 util.inherits(SequelizeStoreException, Error);
 
-module.exports = function SequelizeSessionInit(connect) {
-	var Store = connect.session.Store;
-
+module.exports = function SequelizeSessionInit(Store) {
 	function SequelizeStore(options) {
 		options = options || {};
 		if (!options.db) {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     , "sequelize": ">= 1.6.0"
   }
   , "peerDependencies": {
-    "connect": "*",
     "sequelize": ">= 1.6.0"
   }
   , "engines": {

--- a/test.js
+++ b/test.js
@@ -1,7 +1,7 @@
 
 var assert = require('assert')
 	, connect = require('connect')
-	, SequelizeStore = require('./lib/connect-session-sequelize')(connect)
+	, SequelizeStore = require('./lib/connect-session-sequelize')(connect.session.Store)
 	, Sequelize = require('sequelize');
 
 var db = new Sequelize('session_test', 'test', '12345', {


### PR DESCRIPTION
- Pass Store base class directly instead of connect
- Remove peerDependency on connect
- Update README example

`express.session` is longer accessible in Express 4 and will throw the following error now when initializing this module with express:

```
Error: Most middleware (like session) is no longer bundled with Express and must be installed separately. Please see https://github.com/senchalabs/connect#middleware.
```

I propose changing what is passed to be the `Store` class directly.  You would probably want at least a minor version bump before publishing, if not a major, because of the change in what is being passed.
