### PR TITLE
Running sync on the Session model instead of the entire db.

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ app.use(session({
 // continue as normal
 ```
 
+`SequelizeStore.sync()` - will run a sequelize `sync()` operation on the model for an initialized SequelizeStore object. Use this if you would like the the db table to be created for you.
+
 
 # License
 

--- a/lib/connect-session-sequelize.js
+++ b/lib/connect-session-sequelize.js
@@ -26,10 +26,13 @@ module.exports = function SequelizeSessionInit(Store) {
 		Store.call(this, options);
 
 		this.sessionModel = options.db.import(path.join(__dirname, 'model'));
-		this.sessionModel.sync();
 	}
 
 	util.inherits(SequelizeStore, Store);
+
+	SequelizeStore.prototype.sync = function sync() {
+		this.sessionModel.sync();
+	};
 
 	SequelizeStore.prototype.get = function getSession(sid, fn) {
 		debug('SELECT "%s"', sid);


### PR DESCRIPTION
The sessions model table is still created, but the rest of the existing database is not modified.
