### PR TITLE
Using spread() on findOrCreate returned promise to split callback arguments

### DIFF
--- a/lib/connect-session-sequelize.js
+++ b/lib/connect-session-sequelize.js
@@ -56,7 +56,7 @@ module.exports = function SequelizeSessionInit(Store) {
 	SequelizeStore.prototype.set = function setSession(sid, data, fn) {
 		debug('INSERT "%s"', sid);
 		var stringData = JSON.stringify(data);
-		this.sessionModel.findOrCreate({'sid': sid}, {'data': stringData}).success(function sessionCreated(session) {
+		this.sessionModel.findOrCreate({'sid': sid}, {'data': stringData}).spread(function sessionCreated(session) {
 			if(session['data'] !== stringData) {
 				session['data'] = JSON.stringify(data);
 				session.save().success(function updated(session) {
@@ -72,7 +72,7 @@ module.exports = function SequelizeSessionInit(Store) {
 			} else {
 				fn(null, session);
 			}
-		}).error(function sessionCreatedError(error) {
+		}, function sessionCreatedError(error) {
 			debug('Error creating session: %s', error);
 			if (fn) {
 				fn(error);


### PR DESCRIPTION
Fixes errors for compatibility with Sequelize v2.
