### PR TITLE
Since Sequelice 2.0.0-rc1 Model.findOrCreate takes in where object

### DIFF
--- a/lib/connect-session-sequelize.js
+++ b/lib/connect-session-sequelize.js
@@ -59,7 +59,7 @@ module.exports = function SequelizeSessionInit(Store) {
 	SequelizeStore.prototype.set = function setSession(sid, data, fn) {
 		debug('INSERT "%s"', sid);
 		var stringData = JSON.stringify(data);
-		this.sessionModel.findOrCreate({'sid': sid}, {'data': stringData}).spread(function sessionCreated(session) {
+		this.sessionModel.findOrCreate({where: {'sid': sid, 'data': stringData}}).spread(function sessionCreated(session) {
 			if(session['data'] !== stringData) {
 				session['data'] = JSON.stringify(data);
 				session.save().success(function updated(session) {


### PR DESCRIPTION
Since Sequelice 2.0.0-rc1 Model.findOrCreate takes in where object and throws validation error if old interface is used.

Before my change, test were not passing. Now they are.
