### PR TITLE
leave sync-ing to the implementer

### DIFF
--- a/lib/connect-session-sequelize.js
+++ b/lib/connect-session-sequelize.js
@@ -26,7 +26,6 @@ module.exports = function SequelizeSessionInit(Store) {
 		Store.call(this, options);
 
 		this.sessionModel = options.db.import(path.join(__dirname, 'model'));
-		options.db.sync();
 	}
 
 	util.inherits(SequelizeStore, Store);


### PR DESCRIPTION
Here is a patch for the 1.0 branch which avoids a duplicate sync by leaving the sync call for the implementer.

It looked like this change has already been made for 2.0 support.
