### PR TITLE
Updating sequelize version and using promise style handlers.

### DIFF
--- a/lib/connect-session-sequelize.js
+++ b/lib/connect-session-sequelize.js
@@ -36,7 +36,7 @@ module.exports = function SequelizeSessionInit(Store) {
 
 	SequelizeStore.prototype.get = function getSession(sid, fn) {
 		debug('SELECT "%s"', sid);
-		this.sessionModel.find({where: {'sid': sid}}).success(function(session) {
+		this.sessionModel.find({where: {'sid': sid}}).then(function(session) {
 			if(!session) {
 				debug('Did not find session %s', sid);
 				return fn();
@@ -50,7 +50,7 @@ module.exports = function SequelizeSessionInit(Store) {
 				debug('Error parsing data: %s', e);
 				return fn(e);
 			}
-		}).error(function(error) {
+		}).catch(function(error) {
 			debug('Error finding session: %s', error);
 			fn(error);
 		});
@@ -62,11 +62,11 @@ module.exports = function SequelizeSessionInit(Store) {
 		this.sessionModel.findOrCreate({where: {'sid': sid}, defaults: {'data': stringData}}).spread(function sessionCreated(session) {
 			if(session['data'] !== stringData) {
 				session['data'] = JSON.stringify(data);
-				session.save().success(function updated(session) {
+				session.save().then(function updated(session) {
 					if (fn) {
 						fn(null, data);
 					}
-				}).error(function errorUpdating(error) {
+				}).catch(function errorUpdating(error) {
 					debug('Error updating session: %s', error);
 					if (fn) {
 						fn(error);
@@ -85,31 +85,31 @@ module.exports = function SequelizeSessionInit(Store) {
 
 	SequelizeStore.prototype.destroy = function destroySession(sid, fn) {
 		debug('DESTROYING %s', sid);
-		this.sessionModel.find({where: {'sid': sid}}).success(function foundSession(session) {
+		this.sessionModel.find({where: {'sid': sid}}).then(function foundSession(session) {
 			// If the session wasn't found, then consider it destroyed already.
 			if (session === null) {
 				debug('Session not found, assuming destroyed %s', sid);
 				fn();
 			}
 			else {
-				session.destroy().success(function destroyedSession() {
+				session.destroy().then(function destroyedSession() {
 					debug('Destroyed %s', sid);
 					fn();
-				}).error(function errorDestroying(error) {
+				}).catch(function errorDestroying(error) {
 					debug('Error destroying session: %s', error);
 					fn(error);
 				});
 			}
-		}).error(function errorFindingSession(error) {
+		}).catch(function errorFindingSession(error) {
 			debug('Error finding session: %s', error);
 			fn(error);
 		});
 	};
 
 	SequelizeStore.prototype.length = function calcLength(fn) {
-		this.sessionModel.count().success(function sessionsCount(c) {
+		this.sessionModel.count().then(function sessionsCount(c) {
 			fn(null, c);
-		}).error(function countFailed(error) {
+		}).catch(function countFailed(error) {
 			fn(error);
 		});
 	};

--- a/package.json
+++ b/package.json
@@ -19,10 +19,10 @@
     "mocha": "~1.17.0"
     , "sqlite3": "~2.2.0"
     , "connect": "~2.12.0"
-    , "sequelize": ">= 2.0.0-dev12"
+    , "sequelize": ">= 2.0.0-rc2"
   }
   , "peerDependencies": {
-    "sequelize": ">= 2.0.0-dev12"
+    "sequelize": ">= 2.0.0-rc2"
   }
   , "engines": {
     "node": "*"


### PR DESCRIPTION
This PR uses the current version of sequelize `2.0.0-rc2` which seems a lot nicer than using the dev12 version :D 

It also updates `success()` and `error()` to use the promise-style `then()` and `catch()`. See ya later deprecation warnings.
