### PR TITLE
Update most of the dependencies, fix deprecations, and fix tests.

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,12 +13,12 @@
 	, "url": "https://github.com/mweibel/connect-session-sequelize.git"
   }
   , "dependencies": {
-    "debug": "~0.7.2"
+    "debug": "^2.1.1"
   }
   , "devDependencies": {
-    "mocha": "^1.17.0"
-    , "sqlite3": "^2.2.0"
-    , "connect": "^2.12.0"
+    "mocha": "^2.1.0"
+    , "sqlite3": "^3.0.5"
+    , "express-session": "^1.10.3"
     , "sequelize": ">= 2.0.0-rc2"
   }
   , "peerDependencies": {

--- a/test.js
+++ b/test.js
@@ -1,7 +1,7 @@
 
 var assert = require('assert')
-	, connect = require('connect')
-	, SequelizeStore = require('./lib/connect-session-sequelize')(connect.session.Store)
+	, session = require('express-session')
+	, SequelizeStore = require('./lib/connect-session-sequelize')(session.Store)
 	, Sequelize = require('sequelize');
 
 var db = new Sequelize('session_test', 'test', '12345', {
@@ -13,13 +13,9 @@ var db = new Sequelize('session_test', 'test', '12345', {
 	, sessionData = {foo: 'bar', 'baz': 42};
 
 describe('connect-session-middleware', function() {
-	before(function(done) {
-		store.sync().success(function() {
-			done();
-		}).error(function(err) {
-			done(err);
-		})
-	})
+	before(function() {
+		return store.sync();
+	});
 	it('should have no length', function() {
 		store.length(function(_err, c) {
 			assert.equal(0, c);

--- a/test.js
+++ b/test.js
@@ -16,18 +16,20 @@ describe('connect-session-middleware', function() {
 	before(function() {
 		return store.sync();
 	});
-	it('should have no length', function() {
+	it('should have no length', function(done) {
 		store.length(function(_err, c) {
 			assert.equal(0, c);
+			done();
 		});
 	});
-	it('should save the session', function() {
+	it('should save the session', function(done) {
 		store.set(sessionId, sessionData, function(err, session) {
 			assert.ok(!err, '#set() got an error');
 			assert.ok(session, '#set() is not ok');
 
-			store.length(function(c) {
-				assert.equals(1, c);
+			store.length(function(err, c) {
+				assert.ok(!err, '#length() got an error');
+				assert.equal(1, c, '#length() is not 1');
 
 				store.get(sessionId, function(err, data) {
 					assert.ok(!err, '#get() got an error');
@@ -35,6 +37,7 @@ describe('connect-session-middleware', function() {
 
 					store.destroy(sessionId, function(err) {
 						assert.ok(err, '#destroy() got an error');
+						done();
 					});
 				});
 			});


### PR DESCRIPTION
- debug
- sqlite3
- mocha
- Replace connect with express-session
- Return `.sync()`'s promise instead of using the deprecated `.success()` and `.error()`.
- Fix tests which are completely broken.