### PR TITLE
mweibel/connect-session-sequelize#31 only 32 required

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -4,7 +4,7 @@
 module.exports = function(sequelize, DataTypes) {
   return sequelize.define('Session', {
     sid: {
-      type: DataTypes.STRING,
+      type: DataTypes.STRING(32),
       primaryKey: true
     }
     , expires: DataTypes.DATE


### PR DESCRIPTION
mweibel/connect-session-sequelize#31
sid's length will always be 32 since https://github.com/expressjs/session/blob/85667685a518fb73f2ac6a4cd97d482a3a536584/index.js#L445