### PR TITLE
Add option.extendDefaultFields

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ $ npm install connect-session-sequelize
 
 * `db` a successfully connected Sequelize instance
 * `table` *(optional)* a table/model which has already been imported to your Sequelize instance, this can be used if you want to use a specific table in your db
+* `extendDefaultFields` *(optional)* a way add custom data to table columns. Useful if using a custom model definition
 
 # Usage
 
@@ -79,6 +80,35 @@ new SequelizeStore({
 });
 ```
 
+# Add custom field(s) as a column
+
+The `extendDefaultFields` can be used to add custom fields to the session table. These fields will be read-only as they will be inserted only when the session is first created as `defaults`. Make sure to return an object which contains unmodified `data` and `expires` properties, or else the module functionality will be broken:
+
+```javascript
+var Session = sequelize.define('Session', {
+  sid: {
+    type: Sequelize.STRING,
+    primaryKey: true
+  },
+  userId: Sequelize.STRING,
+  expires: Sequelize.DATE,
+  data: Sequelize.STRING(50000)
+});
+
+function extendDefaultFields(defaults, session) {
+  return {
+    data: defaults.data,
+    expires: defaults.expires,
+    userId: session.userId
+  };
+}
+
+var store = new SessionStore({
+  db: sequelize,
+  table: 'Session',
+  extendDefaultFields: extendDefaultFields
+});
+```
 
 # License
 

--- a/lib/connect-session-sequelize.js
+++ b/lib/connect-session-sequelize.js
@@ -23,19 +23,14 @@ util.inherits(SequelizeStoreException, Error);
 
 module.exports = function SequelizeSessionInit(Store) {
   function SequelizeStore(options) {
-    options = options || {};
+    this.options = options = options || {};
     if (!options.db) {
       throw new SequelizeStoreException('Database connection is required');
     }
 
-    var key;
-    this.options = {};
-    for (key in defaultOptions) {
-      this.options[key] = defaultOptions[key];
-    }
-    for (key in options) {
-      if (key !== 'db') {
-        this.options[key] = options[key];
+    for (var key in defaultOptions) {
+      if (key in options === false) {
+        this.options[key] = defaultOptions[key];
       }
     }
 

--- a/lib/connect-session-sequelize.js
+++ b/lib/connect-session-sequelize.js
@@ -29,7 +29,10 @@ module.exports = function SequelizeSessionInit(Store) {
     }
 
     var key;
-    this.options = defaultOptions;
+    this.options = {};
+    for (key in defaultOptions) {
+      this.options[key] = defaultOptions[key];
+    }
     for (key in options) {
       if (key !== 'db') {
         this.options[key] = options[key];
@@ -82,7 +85,12 @@ module.exports = function SequelizeSessionInit(Store) {
       expires = new Date(Date.now() + this.options.expiration);
     }
 
-    return this.sessionModel.findOrCreate({where: {'sid': sid}, defaults: {'data': stringData, 'expires': expires}}).spread(function sessionCreated(session) {
+    var defaults = {'data': stringData, 'expires': expires};
+    if (this.options.extendDefaultFields) {
+      defaults = this.options.extendDefaultFields(defaults, data);
+    }
+
+    return this.sessionModel.findOrCreate({where: {'sid': sid}, defaults: defaults}).spread(function sessionCreated(session) {
       if(session['data'] !== stringData) {
         session['data'] = JSON.stringify(data);
         session['expires'] = expires;

--- a/test/resources/model.js
+++ b/test/resources/model.js
@@ -7,6 +7,7 @@ module.exports = function(sequelize, DataTypes) {
       type: DataTypes.STRING,
       primaryKey: true
     },
+    userId: DataTypes.STRING,
     expires: DataTypes.DATE,
     data: DataTypes.STRING(50000)
   });


### PR DESCRIPTION
Hi there,

Thank you for this module - I find it very useful.

This functionality allows modification of the default fields stored in the session table. I needed to query sessions per user to enable easier revocation of existing sessions, so I don't have to parse all data in the table to find just a few sessions that might belong to a certain user.

Let me know if you have any questions / comments.

--

The method could be used to store additional data from session to the session
table, for example userId of the user.

The main reason I needed this functionality is to be able to select all
sessions by certain user. For example, I added `userId` string to
session model, and I want that field to be read from session.

The way to do it is to implement an extendDefaultFields function:

```javascript
var Session = sequelize.define('Session', {
    sid: {
      type: Sequelize.STRING,
      primaryKey: true
    },
    userId: Sequelize.STRING,
    expires: Sequelize.DATE,
    data: Sequelize.STRING(50000)
});

function extend(defaults, session) {
    return {
        data: defaults.data,
        expires: defaults.expires,
        userId: session.userId
    };
}

store = new SessionStore({db: db, table: Session, extendDefaultFields: extend});
```

and now `userId` will be stored in the database.