### PR TITLE
Not working for other table. Please correct me if I'm wrong

### DIFF
--- a/lib/connect-session-sequelize.js
+++ b/lib/connect-session-sequelize.js
@@ -41,7 +41,7 @@ module.exports = function SequelizeSessionInit (Store) {
     if (options.table) {
       debug('Using table: %s for sessions', options.table)
       // Get Specifed Table from Sequelize Object
-      this.sessionModel = options.db[options.table] || options.db.models[options.table]
+      this.sessionModel = options.db.models[options.table] || options.db.import(path.join(__dirname, 'model'))
     } else {
       // No Table specified, default to ./model
       debug('No table specified, using default table.')


### PR DESCRIPTION
For example, i try user table Au_sessions
var session = require('express-session'),
Sequelize = require('sequelize'),
SequelizeStore = require('connect-session-sequelize')(session.Store);

var sequelize = new Sequelize(
"dbName",
"dbLogin",
"dbPassword", {
"dialect": "mssql",
"storage": "localhost"
});

SequelizeStore = require('connect-session-sequelize')(session.Store);

// This is the most important path, create noew model
var Session = sequelize.define('Au_Sessions', {
sid: {
type: Sequelize.STRING,
primaryKey: true
},
userId: Sequelize.STRING,
expires: Sequelize.DATE,
data: Sequelize.STRING(50000)
});

function extendDefaultFields(defaults, session) {
console.log('///////////////////////////////////////////');
console.log(session.userId);
return {
data: defaults.data,
expires: defaults.expires,
userId: session.userId
};
}

And this doesn't work, because next part has error
this.sessionModel = options.db[options.table] ||
options.db.models[options.table]

I think, that must be like this:
this.sessionModel = options.db.models[options.table] ||
options.db.import(path.join(__dirname, 'model'))