### PR TITLE
Non transactional session - Sequelize `findOrCreate`

### DIFF
--- a/lib/connect-session-sequelize.js
+++ b/lib/connect-session-sequelize.js
@@ -84,7 +84,7 @@ module.exports = function SequelizeSessionInit (Store) {
       defaults = this.options.extendDefaultFields(defaults, data)
     }
 
-    return this.sessionModel.findOrCreate({where: {'sid': sid}, defaults: defaults}).spread(function sessionCreated (session) {
+    return this.sessionModel.findCreateFind({where: {'sid': sid}, defaults: defaults}).spread(function sessionCreated (session) {
       var changed = false
       Object.keys(defaults).forEach(function (key) {
         if (key === 'data') {

--- a/test/test.js
+++ b/test/test.js
@@ -102,25 +102,29 @@ describe('extendDefaultFields', function () {
     return store.sync()
   })
   it('should extend defaults when extendDefaultFields is set', function (done) {
-    store.set(sessionId, sessionData, function (err, session) {
-      console.log("Error : "+ err)
-      assert.ok(!err, '#set() got an error')
-      assert.ok(session, '#set() is not ok')
+    store.sync().then(function () {
+      store.set(sessionId, sessionData, function (err, session) {
+        assert.ok(!err, '#set() got an error')
+        assert.ok(session, '#set() is not ok')
 
-      db.models.TestSession.findOne({
-        where: {
-          userId: sessionData.baz
-        }
-      })
-      .then(function (_session) {
-        assert.ok(_session, 'session userId not saved')
-        assert.deepEqual(session.dataValues, _session.dataValues)
-
-        store.destroy(sessionId, function (err) {
-          assert.ok(!err, '#destroy() got an error')
-          done()
+        db.models.TestSession.findOne({
+          where: {
+            userId: sessionData.baz
+          }
         })
+          .then(function (_session) {
+            assert.ok(_session, 'session userId not saved')
+            assert.deepEqual(session.dataValues, _session.dataValues)
+
+            store.destroy(sessionId, function (err) {
+              assert.ok(!err, '#destroy() got an error')
+              done()
+            })
+          })
       })
+        .catch(function (err) {
+          assert.of(!err, "Failed to sync the database")
+        })
     })
   })
 

--- a/test/test.js
+++ b/test/test.js
@@ -99,7 +99,11 @@ describe('extendDefaultFields', function () {
     db = new Sequelize('session_test', 'test', '12345', { dialect: 'sqlite', logging: console.log })
     db.import(path.join(__dirname, 'resources/model'))
     store = new SequelizeStore({db: db, table: 'TestSession', extendDefaultFields: extend})
-    store.sync()
+    return store.sync().then(function () {
+        console.log("Migration completed")
+      }).catch(function(err) {
+        logger.error("Could not complete sequelize sync", {'err': err});
+      });
   })
   it('should extend defaults when extendDefaultFields is set', function (done) {
     store.set(sessionId, sessionData, function (err, session) {

--- a/test/test.js
+++ b/test/test.js
@@ -99,7 +99,7 @@ describe('extendDefaultFields', function () {
     db = new Sequelize('session_test', 'test', '12345', { dialect: 'sqlite', logging: console.log })
     db.import(path.join(__dirname, 'resources/model'))
     store = new SequelizeStore({db: db, table: 'TestSession', extendDefaultFields: extend})
-    store.sync().then(function () {
+    return store.sync().then(function () {
         console.log("Migration completed")
       }).catch(function(err) {
         logger.error("Could not complete sequelize sync", {'err': err});

--- a/test/test.js
+++ b/test/test.js
@@ -99,11 +99,7 @@ describe('extendDefaultFields', function () {
     db = new Sequelize('session_test', 'test', '12345', { dialect: 'sqlite', logging: console.log })
     db.import(path.join(__dirname, 'resources/model'))
     store = new SequelizeStore({db: db, table: 'TestSession', extendDefaultFields: extend})
-    return store.sync().then(function () {
-        console.log("Migration completed")
-      }).catch(function(err) {
-        logger.error("Could not complete sequelize sync", {'err': err});
-      });
+    return store.sync()
   })
   it('should extend defaults when extendDefaultFields is set', function (done) {
     store.set(sessionId, sessionData, function (err, session) {

--- a/test/test.js
+++ b/test/test.js
@@ -99,7 +99,7 @@ describe('extendDefaultFields', function () {
     db = new Sequelize('session_test', 'test', '12345', { dialect: 'sqlite', logging: console.log })
     db.import(path.join(__dirname, 'resources/model'))
     store = new SequelizeStore({db: db, table: 'TestSession', extendDefaultFields: extend})
-    return store.sync().then(function () {
+    store.sync().then(function () {
         console.log("Migration completed")
       }).catch(function(err) {
         logger.error("Could not complete sequelize sync", {'err': err});

--- a/test/test.js
+++ b/test/test.js
@@ -103,6 +103,7 @@ describe('extendDefaultFields', function () {
   })
   it('should extend defaults when extendDefaultFields is set', function (done) {
     store.set(sessionId, sessionData, function (err, session) {
+      console.log("Error : "+ err)
       assert.ok(!err, '#set() got an error')
       assert.ok(session, '#set() is not ok')
 


### PR DESCRIPTION
`SequelizeStore.prototype.set` currently uses the sequelize `findOrCreate` that selects and inserts (if necessary) in a transaction.
 For the purpose of sequelize store set, this is probably not required as
 updating the same session concurrently in more than one request might not be
 applicable.
 The reason for this PR is the observation of high memory usage and eventually crashing the DB
 under postgres when `findOrCreate` is used. The underlying reason for this is that sequelize uses temp functions setup transactions and trace any failures. Postgres keeps a cache of temp functions and under high rate of creating sessions (by users hitting a page that requires session creation), postgress can't cleanup the cache and as a result falls over once all of the swap is utilised.

This change is to use the more performant non-transactional `findCreateFind` function as per a discussion with the sequelize community in their slack channel. 

This pull request questions if transactions are really required for the `SequelizeStore.prototype.set` and if not proposing to use the `findCreateFind`.