### PR TITLE
Remove unnecessary files from NPM package

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,5 +39,6 @@
     "sqlite"
   ],
   "author": "Michael Weibel <michael.weibel@gmail.com> (https://github.com/mweibel)",
-  "license": "MIT"
+  "license": "MIT",
+  "files": ["lib"]
 }


### PR DESCRIPTION
Note that README.md, package.json and index.js are included in the package regardless of the `files` array.

This will remove the following files/directories from the package:

- .idea (not in git, but added locally somehow)
- test
- .npmignore
- .travis.yml
- yarn.lock

If you like to keep the tests in the package (this is a matter of preference), please let me know.