### PR TITLE
Support sequelize operator symbols.

### DIFF
--- a/lib/connect-session-sequelize.js
+++ b/lib/connect-session-sequelize.js
@@ -7,6 +7,7 @@
 
 var util = require('util')
 var path = require('path')
+var Op = require('sequelize').Op || {};
 var debug = require('debug')('connect:session-sequelize')
 var defaultOptions = {
   checkExpirationInterval: 15 * 60 * 1000, // The interval at which to cleanup expired sessions.
@@ -141,7 +142,7 @@ module.exports = function SequelizeSessionInit (Store) {
 
   SequelizeStore.prototype.clearExpiredSessions = function clearExpiredSessions (fn) {
     debug('CLEARING EXPIRED SESSIONS')
-    return this.sessionModel.destroy({where: {'expires': {lt: new Date()}}}).asCallback(fn)
+    return this.sessionModel.destroy({where: {'expires': {[Op.lt || 'lt']: new Date()}}}).asCallback(fn)
   }
 
   SequelizeStore.prototype.startExpiringSessions = function startExpiringSessions () {


### PR DESCRIPTION
This commit should fix an error that Sequelize produces, when passing operatorsAliases: false in options to the Sequelize constructor.

The reason why one would set that option is to avoid the warning Sequelize now produces when it is not declared.

Thank you for this awesome module!