### PR TITLE
Prevent crash in SequelizeStore.set

### DIFF
--- a/lib/connect-session-sequelize.js
+++ b/lib/connect-session-sequelize.js
@@ -87,7 +87,7 @@ module.exports = function SequelizeSessionInit (Store) {
       defaults = this.options.extendDefaultFields(defaults, data)
     }
 
-    return this.sessionModel.findCreateFind({where: {'sid': sid}, defaults: defaults})
+    return this.sessionModel.findCreateFind({where: {'sid': sid}, defaults: defaults, raw: false})
     .spread(function sessionCreated (session) {
       var changed = false
       Object.keys(defaults).forEach(function (key) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "connect-session-sequelize",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "description": "Session store for connect-session using sequelize",
   "homepage": "https://github.com/mweibel/connect-session-sequelize",
   "bugs": "https://github.com/mweibel/connect-session-sequelize/issues",

--- a/test/test.js
+++ b/test/test.js
@@ -95,6 +95,21 @@ describe('#set()', function () {
       })
     })
   })
+  it('should have model instance methods', function (done) {
+    store.set(sessionId, sessionData, function (err, session) {
+      assert.ok(!err, '#set() got an error')
+      assert.ok(session, '#set() is not ok')
+
+      assert.ok(session.dataValues)
+      assert.ok(session.update)
+      assert.ok(session.save)
+
+      store.destroy(sessionId, function (err) {
+        assert.ok(!err, '#destroy() got an error')
+        done()
+      })
+    })
+  })
 })
 
 describe('extendDefaultFields', function () {


### PR DESCRIPTION
First of all @mweibel thanks for writing this package!

The logic in SequelizeStore.set implicitly depends on the Sequelize instance or models to be configured with `{ raw: false }`; it relies on `session.save` being a function and `session.dataValues` being present, which isn't the case for application code being configured with `{ raw: true }` (in which case you don't get a Model instance back).

At our company we configured in our application code `{ raw: true }` and when we try to mutate sessions we get this error and fail to update the Session object in the DB.