### PR TITLE
Prevent crash on destroy method

### DIFF
--- a/lib/connect-session-sequelize.js
+++ b/lib/connect-session-sequelize.js
@@ -135,7 +135,7 @@ module.exports = function SequelizeSessionInit (Store) {
 
   SequelizeStore.prototype.destroy = function destroySession (sid, fn) {
     debug('DESTROYING %s', sid)
-    return this.sessionModel.find({where: {'sid': sid}}).then(function foundSession (session) {
+    return this.sessionModel.find({where: {'sid': sid},raw: false}).then(function foundSession (session) {
       // If the session wasn't found, then consider it destroyed already.
       if (session === null) {
         debug('Session not found, assuming destroyed %s', sid)

--- a/lib/connect-session-sequelize.js
+++ b/lib/connect-session-sequelize.js
@@ -135,7 +135,7 @@ module.exports = function SequelizeSessionInit (Store) {
 
   SequelizeStore.prototype.destroy = function destroySession (sid, fn) {
     debug('DESTROYING %s', sid)
-    return this.sessionModel.find({where: {'sid': sid},raw: false}).then(function foundSession (session) {
+    return this.sessionModel.find({where: {'sid': sid}, raw: false}).then(function foundSession (session) {
       // If the session wasn't found, then consider it destroyed already.
       if (session === null) {
         debug('Session not found, assuming destroyed %s', sid)


### PR DESCRIPTION
Prevent destroy method to crash if Sequelize has the following global config:

```
query: {
    raw: true
}
```

**Issue:**
`TypeError: session.destroy is not a function`

**Solution:**
Added `raw: false` option in destroy method to return always the Model instance instead of dataValues