### PR TITLE
Changed session.sid from string(32) to string(36)

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -4,7 +4,7 @@
 module.exports = function (sequelize, DataTypes) {
   return sequelize.define('Session', {
     sid: {
-      type: DataTypes.STRING(32),
+      type: DataTypes.STRING(36),
       primaryKey: true
     },
     expires: DataTypes.DATE,


### PR DESCRIPTION
UUID are yes 32char long but as per RFC4122 spec, value is splitted in 4 octect separated by hyphens making it a total of 36  char.