### PR TITLE
Sequelize has deprecated find in favour of findOne

### DIFF
--- a/lib/connect-session-sequelize.js
+++ b/lib/connect-session-sequelize.js
@@ -60,7 +60,7 @@ module.exports = function SequelizeSessionInit (Store) {
 
   SequelizeStore.prototype.get = function getSession (sid, fn) {
     debug('SELECT "%s"', sid)
-    return this.sessionModel.find({where: {'sid': sid}}).then(function (session) {
+    return this.sessionModel.findOne({where: {'sid': sid}}).then(function (session) {
       if (!session) {
         debug('Did not find session %s', sid)
         return null
@@ -135,7 +135,7 @@ module.exports = function SequelizeSessionInit (Store) {
 
   SequelizeStore.prototype.destroy = function destroySession (sid, fn) {
     debug('DESTROYING %s', sid)
-    return this.sessionModel.find({where: {'sid': sid}, raw: false}).then(function foundSession (session) {
+    return this.sessionModel.findOne({where: {'sid': sid}, raw: false}).then(function foundSession (session) {
       // If the session wasn't found, then consider it destroyed already.
       if (session === null) {
         debug('Session not found, assuming destroyed %s', sid)

--- a/test/test.js
+++ b/test/test.js
@@ -9,6 +9,7 @@ var Sequelize = require('sequelize')
 Sequelize.Promise.longStackTraces()
 
 var db = new Sequelize('session_test', 'test', '12345', {
+  operatorsAliases: false,
   dialect: 'sqlite',
   logging: false
 })
@@ -39,7 +40,7 @@ describe('store', function () {
 describe('store db', function () {
   var db = {}
   beforeEach(function () {
-    db = new Sequelize('session_test', 'test', '12345', {dialect: 'sqlite', logging: false})
+    db = new Sequelize('session_test', 'test', '12345', {operatorsAliases: false, dialect: 'sqlite', logging: false})
     db.import(path.join(__dirname, 'resources/model'))
   })
 
@@ -120,7 +121,7 @@ describe('extendDefaultFields', function () {
       return defaults
     }
 
-    db = new Sequelize('session_test', 'test', '12345', {dialect: 'sqlite', logging: console.log})
+    db = new Sequelize('session_test', 'test', '12345', {operatorsAliases: false, dialect: 'sqlite', logging: console.log})
     db.import(path.join(__dirname, 'resources/model'))
     store = new SequelizeStore({db: db, table: 'TestSession', extendDefaultFields: extend, checkExpirationInterval: -1})
     return store.sync()
@@ -278,7 +279,7 @@ describe('#stopExpiringSessions()', function () {
       'session_test',
       'test',
       '12345',
-      {dialect: 'sqlite', logging: false}
+      {operatorsAliases: false, dialect: 'sqlite', logging: false}
     )
     db.import(path.join(__dirname, 'resources/model'))
     store = new SequelizeStore({

--- a/test/test.js
+++ b/test/test.js
@@ -193,7 +193,7 @@ describe('#touch()', function () {
       store.touch(sessionId, sessionData, function (err) {
         assert.ok(!err, '#touch() got an error')
 
-        store.sessionModel.find({where: {'sid': sessionId}}).then(function (session) {
+        store.sessionModel.findOne({where: {'sid': sessionId}}).then(function (session) {
           assert.ok(session.expires.getTime() !== firstExpires.getTime(), '.expires has not changed')
           assert.ok(session.expires > firstExpires, '.expires is not newer')
 
@@ -202,7 +202,7 @@ describe('#touch()', function () {
             done()
           })
         }, function (err) {
-          assert.ok(!err, 'store.sessionModel.find() got an error')
+          assert.ok(!err, 'store.sessionModel.findOne() got an error')
           done(err)
         })
       })
@@ -227,7 +227,7 @@ describe('#disableTouch()', function () {
       store.touch(sessionId, sessionData, function (err) {
         assert.ok(!err, '#touch() got an error')
 
-        store.sessionModel.find({where: {'sid': sessionId}}).then(function (session) {
+        store.sessionModel.findOne({where: {'sid': sessionId}}).then(function (session) {
           assert.ok(session.expires.getTime() === firstExpires.getTime(), '.expires was incorrectly changed')
 
           store.destroy(sessionId, function (err) {
@@ -235,7 +235,7 @@ describe('#disableTouch()', function () {
             done()
           })
         }, function (err) {
-          assert.ok(!err, 'store.sessionModel.find() got an error')
+          assert.ok(!err, 'store.sessionModel.findOne() got an error')
           done(err)
         })
       })


### PR DESCRIPTION
Pull request to fix #79.

Prior to this patch, the model methods `find` and `findOne` were used interchangeably (they were aliases provided by sequelize). In sequelize v4.41.0 aliases were deprecated and canonical methods provided, in this case `findOne`; using `find` now produces warnings in applications which depend on connect-session-sequelize.

I have run tests, which pass for me and do not produce any other warnings about methods (previously running tests also produced warnings about find).

I was also getting a warning from the tests themselves when calling `new Sequelize` but have since been directed to a workaround which fixes the issue and have pushed that commit to this branch as well.