### PR TITLE
Using JS object as in-memory cache

### DIFF
--- a/lib/connect-session-sequelize.js
+++ b/lib/connect-session-sequelize.js
@@ -66,7 +66,7 @@ module.exports = function SequelizeSessionInit (Store) {
   SequelizeStore.prototype.get = function getSession (sid, fn) {
     debug('SELECT "%s"', sid)
     if (this.options.useCache && this.cache[sid]) {
-      debug('FOUND "%s" in cache with data %s', sid, this.cache[sid].data)
+      debug('FOUND "%s" in cache', sid)
       return require('sequelize')
         .Promise.resolve(JSON.parse(this.cache[sid].data))
         .asCallback(fn)
@@ -126,7 +126,7 @@ module.exports = function SequelizeSessionInit (Store) {
           return session.save().return(session)
         }
         if (self.options.useCache) {
-          debug('Persisting "%s" in cache also', sid)
+          debug('Storing "%s" data in cache', sid)
           self.cache[sid] = session
         }
         return session
@@ -149,7 +149,7 @@ module.exports = function SequelizeSessionInit (Store) {
       expires = new Date(Date.now() + this.options.expiration)
     }
     if (this.options.useCache) {
-      debug('Modifying expiry for "%s" in cache also', sid)
+      debug('Modifying expiry for "%s" in cache', sid)
       this.cache[sid].expires = expires
     }
 

--- a/lib/connect-session-sequelize.js
+++ b/lib/connect-session-sequelize.js
@@ -12,7 +12,8 @@ var debug = require('debug')('connect:session-sequelize')
 var defaultOptions = {
   checkExpirationInterval: 15 * 60 * 1000, // The interval at which to cleanup expired sessions.
   expiration: 24 * 60 * 60 * 1000, // The maximum age (in milliseconds) of a valid session. Used when cookie.expires is not set.
-  disableTouch: false // When true, we will not update the db in the touch function call. Useful when you want more control over db writes.
+  disableTouch: false, // When true, we will not update the db in the touch function call. Useful when you want more control over db writes.
+  useCache: false
 }
 
 function SequelizeStoreException (message) {
@@ -50,6 +51,10 @@ module.exports = function SequelizeSessionInit (Store) {
       debug('No table specified, using default table.')
       this.sessionModel = options.db.import(path.join(__dirname, 'model'))
     }
+    if (options.useCache) {
+      debug('Using in memory cache for sessions')
+      this.cache = {}
+    }
   }
 
   util.inherits(SequelizeStore, Store)
@@ -60,6 +65,13 @@ module.exports = function SequelizeSessionInit (Store) {
 
   SequelizeStore.prototype.get = function getSession (sid, fn) {
     debug('SELECT "%s"', sid)
+    if (this.options.useCache && this.cache[sid]) {
+      debug('FOUND "%s" in cache with data %s', sid, this.cache[sid].data)
+      return require('sequelize')
+        .Promise.resolve(JSON.parse(this.cache[sid].data))
+        .asCallback(fn)
+    }
+    var self = this
     return this.sessionModel.findOne({ where: { 'sid': sid } }).then(function (session) {
       if (!session) {
         debug('Did not find session %s', sid)
@@ -67,6 +79,10 @@ module.exports = function SequelizeSessionInit (Store) {
       }
       debug('FOUND %s with data %s', session.sid, session.data)
 
+      if (self.options.useCache) {
+        debug('Setting cache with data for %s', session.sid)
+        self.cache[sid] = session
+      }
       return JSON.parse(session.data)
     }).asCallback(fn)
   }
@@ -76,6 +92,7 @@ module.exports = function SequelizeSessionInit (Store) {
     var stringData = JSON.stringify(data)
     var expires
 
+    var self = this
     if (data.cookie && data.cookie.expires) {
       expires = data.cookie.expires
     } else {
@@ -108,6 +125,10 @@ module.exports = function SequelizeSessionInit (Store) {
           session.expires = expires
           return session.save().return(session)
         }
+        if (self.options.useCache) {
+          debug('Persisting "%s" in cache also', sid)
+          self.cache[sid] = session
+        }
         return session
       }).asCallback(fn)
   }
@@ -127,6 +148,10 @@ module.exports = function SequelizeSessionInit (Store) {
     } else {
       expires = new Date(Date.now() + this.options.expiration)
     }
+    if (this.options.useCache) {
+      debug('Modifying expiry for "%s" in cache also', sid)
+      this.cache[sid].expires = expires
+    }
 
     return this.sessionModel.update({ 'expires': expires }, { where: { 'sid': sid } }).then(function (rows) {
       return rows
@@ -135,6 +160,10 @@ module.exports = function SequelizeSessionInit (Store) {
 
   SequelizeStore.prototype.destroy = function destroySession (sid, fn) {
     debug('DESTROYING %s', sid)
+    if (this.options.useCache) {
+      debug('Removing %s from cache', sid)
+      delete this.cache[sid]
+    }
     return this.sessionModel.findOne({ where: { 'sid': sid }, raw: false }).then(function foundSession (session) {
       // If the session wasn't found, then consider it destroyed already.
       if (session === null) {
@@ -151,6 +180,13 @@ module.exports = function SequelizeSessionInit (Store) {
 
   SequelizeStore.prototype.clearExpiredSessions = function clearExpiredSessions (fn) {
     debug('CLEARING EXPIRED SESSIONS')
+    if (this.options.useCache) {
+      for (const [sid, entry] of Object.entries(this.cache)) {
+        if (entry.expires < new Date()) {
+          delete this.cache[sid]
+        }
+      }
+    }
     return this.sessionModel.destroy({ where: { 'expires': { [Op.lt || 'lt']: new Date() } } }).asCallback(fn)
   }
 

--- a/test/test.js
+++ b/test/test.js
@@ -56,244 +56,261 @@ describe('store db', function () {
   })
 })
 
-describe('#set()', function () {
-  before(function () {
-    return store.sync()
-  })
-  it('should save the session', function (done) {
-    store.set(sessionId, sessionData, function (err, session) {
-      assert.ok(!err, '#set() got an error')
-      assert.ok(session, '#set() is not ok')
-
-      store.length(function (err, c) {
-        assert.ok(!err, '#length() got an error')
-        assert.strictEqual(1, c, '#length() is not 1')
-
-        store.get(sessionId, function (err, data) {
-          assert.ok(!err, '#get() got an error')
-          assert.deepStrictEqual(sessionData, data)
-
-          store.destroy(sessionId, function (err) {
-            assert.ok(!err, '#destroy() got an error')
-            done()
-          })
-        })
-      })
+var sessionTests = function (useCache) {
+  describe('#set()', function () {
+    before(function () {
+      return store.sync()
     })
-  })
-  it('should have a future expires', function (done) {
-    store.set(sessionId, sessionData, function (err, session) {
-      assert.ok(!err, '#set() got an error')
-      assert.ok(session, '#set() is not ok')
-
-      assert.ok(session.expires, '.expires does not exist')
-      assert.ok(session.expires instanceof Date, '.expires is not a date')
-      assert.ok(session.expires > new Date(), '.expires is not in the future')
-
-      store.destroy(sessionId, function (err) {
-        assert.ok(!err, '#destroy() got an error')
-        done()
-      })
-    })
-  })
-  it('should have model instance methods', function (done) {
-    store.set(sessionId, sessionData, function (err, session) {
-      assert.ok(!err, '#set() got an error')
-      assert.ok(session, '#set() is not ok')
-
-      assert.ok(session.dataValues)
-      assert.ok(session.update)
-      assert.ok(session.save)
-
-      store.destroy(sessionId, function (err) {
-        assert.ok(!err, '#destroy() got an error')
-        done()
-      })
-    })
-  })
-})
-
-describe('extendDefaultFields', function () {
-  var db, store
-  before(function () {
-    function extend (defaults, session) {
-      defaults.userId = session.baz
-      return defaults
-    }
-
-    db = new Sequelize('session_test', 'test', '12345', { operatorsAliases: false, dialect: 'sqlite', logging: console.log })
-    db.import(path.join(__dirname, 'resources/model'))
-    store = new SequelizeStore({ db: db, table: 'TestSession', extendDefaultFields: extend, checkExpirationInterval: -1 })
-    return store.sync()
-  })
-  it('should extend defaults when extendDefaultFields is set', function (done) {
-    store.sync().then(function () {
+    it('should save the session', function (done) {
       store.set(sessionId, sessionData, function (err, session) {
         assert.ok(!err, '#set() got an error')
         assert.ok(session, '#set() is not ok')
 
-        db.models.TestSession.findOne({
-          where: {
-            userId: sessionData.baz
-          }
-        })
-          .then(function (_session) {
-            assert.ok(_session, 'session userId not saved')
-            assert.deepStrictEqual(session.dataValues, _session.dataValues)
+        store.length(function (err, c) {
+          assert.ok(!err, '#length() got an error')
+          assert.strictEqual(1, c, '#length() is not 1')
+
+          store.get(sessionId, function (err, data) {
+            assert.ok(!err, '#get() got an error')
+            assert.deepStrictEqual(sessionData, data)
 
             store.destroy(sessionId, function (err) {
               assert.ok(!err, '#destroy() got an error')
               done()
             })
           })
-      })
-        .catch(function (err) {
-          assert.ifError(err)
         })
+      })
     })
-  })
-
-  it('should update fields when extendDefaultFields is set', function (done) {
-    store.set('testupdateFields', { foo: 'bar' }, function (err, session) {
-      assert.ok(!err, '#set() got an error')
-      assert.ok(session, '#set() is not ok')
-
-      store.set('testupdateFields', { baz: 'baz', yolo: 'haha' }, function (err, innerSession) {
+    it('should have a future expires', function (done) {
+      store.set(sessionId, sessionData, function (err, session) {
         assert.ok(!err, '#set() got an error')
-        assert.ok(innerSession, '#set() is not ok')
+        assert.ok(session, '#set() is not ok')
 
-        db.models.TestSession.findOne({
-          where: {
-            userId: 'baz'
-          }
+        assert.ok(session.expires, '.expires does not exist')
+        assert.ok(session.expires instanceof Date, '.expires is not a date')
+        assert.ok(session.expires > new Date(), '.expires is not in the future')
+
+        store.destroy(sessionId, function (err) {
+          assert.ok(!err, '#destroy() got an error')
+          done()
         })
-          .then(function (_session) {
-            assert.ok(_session, 'session userId not saved')
-            assert.deepStrictEqual(innerSession.dataValues, _session.dataValues)
+      })
+    })
+    it('should have model instance methods', function (done) {
+      store.set(sessionId, sessionData, function (err, session) {
+        assert.ok(!err, '#set() got an error')
+        assert.ok(session, '#set() is not ok')
+
+        assert.ok(session.dataValues)
+        assert.ok(session.update)
+        assert.ok(session.save)
+
+        store.destroy(sessionId, function (err) {
+          assert.ok(!err, '#destroy() got an error')
+          done()
+        })
+      })
+    })
+  })
+
+  describe('extendDefaultFields', function () {
+    var db, store
+    before(function () {
+      function extend (defaults, session) {
+        defaults.userId = session.baz
+        return defaults
+      }
+
+      db = new Sequelize('session_test', 'test', '12345', { operatorsAliases: false, dialect: 'sqlite', logging: console.log })
+      db.import(path.join(__dirname, 'resources/model'))
+      store = new SequelizeStore({ db: db, table: 'TestSession', extendDefaultFields: extend, checkExpirationInterval: -1, useCache: useCache })
+      return store.sync()
+    })
+    it('should extend defaults when extendDefaultFields is set', function (done) {
+      store.sync().then(function () {
+        store.set(sessionId, sessionData, function (err, session) {
+          assert.ok(!err, '#set() got an error')
+          assert.ok(session, '#set() is not ok')
+
+          db.models.TestSession.findOne({
+            where: {
+              userId: sessionData.baz
+            }
+          })
+            .then(function (_session) {
+              assert.ok(_session, 'session userId not saved')
+              assert.deepStrictEqual(session.dataValues, _session.dataValues)
+
+              store.destroy(sessionId, function (err) {
+                assert.ok(!err, '#destroy() got an error')
+                done()
+              })
+            })
+        })
+          .catch(function (err) {
+            assert.ifError(err)
+          })
+      })
+    })
+
+    it('should update fields when extendDefaultFields is set', function (done) {
+      store.set('testupdateFields', { foo: 'bar' }, function (err, session) {
+        assert.ok(!err, '#set() got an error')
+        assert.ok(session, '#set() is not ok')
+
+        store.set('testupdateFields', { baz: 'baz', yolo: 'haha' }, function (err, innerSession) {
+          assert.ok(!err, '#set() got an error')
+          assert.ok(innerSession, '#set() is not ok')
+
+          db.models.TestSession.findOne({
+            where: {
+              userId: 'baz'
+            }
+          })
+            .then(function (_session) {
+              assert.ok(_session, 'session userId not saved')
+              assert.deepStrictEqual(innerSession.dataValues, _session.dataValues)
+
+              store.destroy(sessionId, function (err) {
+                assert.ok(!err, '#destroy() got an error')
+                done()
+              })
+            })
+        })
+      })
+    })
+  })
+
+  describe('#touch()', function () {
+    before(function () {
+      return store.sync()
+    })
+    it('should update the expires', function (done) {
+      store.set(sessionId, sessionData, function (err, session) {
+        assert.ok(!err, '#set() got an error')
+        assert.ok(session, '#set() is not ok')
+
+        var firstExpires = session.expires
+        store.touch(sessionId, sessionData, function (err) {
+          assert.ok(!err, '#touch() got an error')
+
+          store.sessionModel.findOne({ where: { 'sid': sessionId } }).then(function (session) {
+            assert.ok(session.expires.getTime() !== firstExpires.getTime(), '.expires has not changed')
+            assert.ok(session.expires > firstExpires, '.expires is not newer')
 
             store.destroy(sessionId, function (err) {
               assert.ok(!err, '#destroy() got an error')
               done()
             })
+          }, function (err) {
+            assert.ok(!err, 'store.sessionModel.findOne() got an error')
+            done(err)
           })
+        })
       })
     })
   })
-})
 
-describe('#touch()', function () {
-  before(function () {
-    return store.sync()
+  describe('#disableTouch()', function () {
+    before(function () {
+      store.options.disableTouch = true
+      return store.sync()
+    })
+    after('set disableTouch back to false.', function () {
+      store.options.disableTouch = false
+    })
+    it('should NOT update the expires', function (done) {
+      store.set(sessionId, sessionData, function (err, session) {
+        assert.ok(!err, '#set() got an error')
+        assert.ok(session, '#set() is not ok')
+
+        var firstExpires = session.expires
+        store.touch(sessionId, sessionData, function (err) {
+          assert.ok(!err, '#touch() got an error')
+
+          store.sessionModel.findOne({ where: { 'sid': sessionId } }).then(function (session) {
+            assert.ok(session.expires.getTime() === firstExpires.getTime(), '.expires was incorrectly changed')
+
+            store.destroy(sessionId, function (err) {
+              assert.ok(!err, '#destroy() got an error')
+              done()
+            })
+          }, function (err) {
+            assert.ok(!err, 'store.sessionModel.findOne() got an error')
+            done(err)
+          })
+        })
+      })
+    })
   })
-  it('should update the expires', function (done) {
-    store.set(sessionId, sessionData, function (err, session) {
-      assert.ok(!err, '#set() got an error')
-      assert.ok(session, '#set() is not ok')
 
-      var firstExpires = session.expires
-      store.touch(sessionId, sessionData, function (err) {
-        assert.ok(!err, '#touch() got an error')
+  describe('#clearExpiredSessions()', function () {
+    before(function () {
+      return store.sync()
+    })
+    it('should delete expired sessions', function (done) {
+      store.set(sessionId, sessionData, function (err, session) {
+        assert.ok(!err, '#set() got an error')
+        assert.ok(session, '#set() is not ok')
 
-        store.sessionModel.findOne({ where: { 'sid': sessionId } }).then(function (session) {
-          assert.ok(session.expires.getTime() !== firstExpires.getTime(), '.expires has not changed')
-          assert.ok(session.expires > firstExpires, '.expires is not newer')
+        session.expires = new Date(Date.now() - 3600000)
+        session.save().then(function () {
+          store.clearExpiredSessions(function (err) {
+            assert.ok(!err, '#clearExpiredSessions() got an error')
 
-          store.destroy(sessionId, function (err) {
-            assert.ok(!err, '#destroy() got an error')
-            done()
+            store.length(function (err, c) {
+              assert.ok(!err, '#length() got an error')
+              assert.strictEqual(0, c, 'the expired session wasn\'t deleted')
+              done()
+            })
           })
         }, function (err) {
-          assert.ok(!err, 'store.sessionModel.findOne() got an error')
+          assert.ok(!err, 'session.save() got an error')
           done(err)
         })
       })
     })
   })
-})
 
-describe('#disableTouch()', function () {
-  before(function () {
-    store.options.disableTouch = true
-    return store.sync()
-  })
-  after('set disableTouch back to false.', function () {
-    store.options.disableTouch = false
-  })
-  it('should NOT update the expires', function (done) {
-    store.set(sessionId, sessionData, function (err, session) {
-      assert.ok(!err, '#set() got an error')
-      assert.ok(session, '#set() is not ok')
-
-      var firstExpires = session.expires
-      store.touch(sessionId, sessionData, function (err) {
-        assert.ok(!err, '#touch() got an error')
-
-        store.sessionModel.findOne({ where: { 'sid': sessionId } }).then(function (session) {
-          assert.ok(session.expires.getTime() === firstExpires.getTime(), '.expires was incorrectly changed')
-
-          store.destroy(sessionId, function (err) {
-            assert.ok(!err, '#destroy() got an error')
-            done()
-          })
-        }, function (err) {
-          assert.ok(!err, 'store.sessionModel.findOne() got an error')
-          done(err)
-        })
+  describe('#stopExpiringSessions()', function () {
+    var store
+    beforeEach(function () {
+      var db = new Sequelize(
+        'session_test',
+        'test',
+        '12345',
+        { operatorsAliases: false, dialect: 'sqlite', logging: false }
+      )
+      db.import(path.join(__dirname, 'resources/model'))
+      store = new SequelizeStore({
+        db: db,
+        table: 'TestSession',
+        checkExpirationInterval: 100,
+        useCache: useCache
       })
     })
-  })
-})
-
-describe('#clearExpiredSessions()', function () {
-  before(function () {
-    return store.sync()
-  })
-  it('should delete expired sessions', function (done) {
-    store.set(sessionId, sessionData, function (err, session) {
-      assert.ok(!err, '#set() got an error')
-      assert.ok(session, '#set() is not ok')
-
-      session.expires = new Date(Date.now() - 3600000)
-      session.save().then(function () {
-        store.clearExpiredSessions(function (err) {
-          assert.ok(!err, '#clearExpiredSessions() got an error')
-
-          store.length(function (err, c) {
-            assert.ok(!err, '#length() got an error')
-            assert.strictEqual(0, c, 'the expired session wasn\'t deleted')
-            done()
-          })
-        })
-      }, function (err) {
-        assert.ok(!err, 'session.save() got an error')
-        done(err)
-      })
+    afterEach('clean up resources', function () {
+      store.stopExpiringSessions()
+    })
+    it('should cancel the session check timer', function () {
+      assert.ok(store._expirationInterval, 'missing timeout object')
+      store.stopExpiringSessions()
+      assert.strictEqual(store._expirationInterval, null, 'expiration interval not nullified')
     })
   })
+}
+
+describe('with cache', function () {
+  var useCache = true
+  store = new SequelizeStore({
+    db: db,
+    checkExpirationInterval: 100,
+    useCache: useCache
+  })
+  sessionTests(useCache)
 })
 
-describe('#stopExpiringSessions()', function () {
-  var store
-  beforeEach(function () {
-    var db = new Sequelize(
-      'session_test',
-      'test',
-      '12345',
-      { operatorsAliases: false, dialect: 'sqlite', logging: false }
-    )
-    db.import(path.join(__dirname, 'resources/model'))
-    store = new SequelizeStore({
-      db: db,
-      table: 'TestSession',
-      checkExpirationInterval: 100
-    })
-  })
-  afterEach('clean up resources', function () {
-    store.stopExpiringSessions()
-  })
-  it('should cancel the session check timer', function () {
-    assert.ok(store._expirationInterval, 'missing timeout object')
-    store.stopExpiringSessions()
-    assert.strictEqual(store._expirationInterval, null, 'expiration interval not nullified')
-  })
+describe('without cache', function () {
+  sessionTests()
 })


### PR DESCRIPTION
I notice that sequelize queries against my database would, at random times, become 2 orders of magnitude slower (usually takes 3-9ms, will spike up to 200-300ms). That's a significant blocker. I was unable to narrow down the cause on my end so I thought to remove the need for the database as much as possible. I've incorporated code that allows for the server to have the session information stored in memory so that one doesn't need to fetch it from the DB, but in case it doesn't find it, it'll rely on the database as the final source of truth.

I'd love your comments on how I can improve this in its current form. It's alright if you don't want to merge this back into master - it provides my product value so I thought others might find it useful. Thanks @mweibel!