### PR TITLE
Documentation fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ $ npm install connect-session-sequelize
 
 * `db` a successfully connected Sequelize instance
 * `table` *(optional)* a table/model which has already been imported to your Sequelize instance, this can be used if you want to use a specific table in your db
+* `defaultModelKey` *(optional)* a string for the key in sequelize's models-object but it is also the name of the class to which it references (conventionally written in Camelcase) that's why it is "Session" by default
+* `defaultTableName` *(optional)* a string for naming the generated table if `table` is not defined.
+Default is the value of `defaultModelKey`.
 * `extendDefaultFields` *(optional)* a way add custom data to table columns. Useful if using a custom model definition
 * `disableTouch` *(optional)* When true, the store will not update the db when receiving a touch() call. This can be useful in limiting db writes and introducing more manual control of session updates.
 

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ $ npm install connect-session-sequelize
 
 * `db` a successfully connected Sequelize instance
 * `table` *(optional)* a table/model which has already been imported to your Sequelize instance, this can be used if you want to use a specific table in your db
-* `defaultModelKey` *(optional)* a string for the key in sequelize's models-object but it is also the name of the class to which it references (conventionally written in Camelcase) that's why it is "Session" by default
-* `defaultTableName` *(optional)* a string for naming the generated table if `table` is not defined.
+* `modelKey` *(optional)* a string for the key in sequelize's models-object but it is also the name of the class to which it references (conventionally written in Camelcase) that's why it is "Session" by default if `table` is not defined.
+* `tableName` *(optional)* a string for naming the generated table if `table` is not defined.
 Default is the value of `defaultModelKey`.
 * `extendDefaultFields` *(optional)* a way add custom data to table columns. Useful if using a custom model definition
 * `disableTouch` *(optional)* When true, the store will not update the db when receiving a touch() call. This can be useful in limiting db writes and introducing more manual control of session updates.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ $ npm install connect-session-sequelize
 * `table` *(optional)* a table/model which has already been imported to your Sequelize instance, this can be used if you want to use a specific table in your db
 * `modelKey` *(optional)* a string for the key in sequelize's models-object but it is also the name of the class to which it references (conventionally written in Camelcase) that's why it is "Session" by default if `table` is not defined.
 * `tableName` *(optional)* a string for naming the generated table if `table` is not defined.
-Default is the value of `defaultModelKey`.
+Default is the value of `modelKey`.
 * `extendDefaultFields` *(optional)* a way add custom data to table columns. Useful if using a custom model definition
 * `disableTouch` *(optional)* When true, the store will not update the db when receiving a touch() call. This can be useful in limiting db writes and introducing more manual control of session updates.
 

--- a/lib/connect-session-sequelize.js
+++ b/lib/connect-session-sequelize.js
@@ -12,7 +12,9 @@ const debug = require('debug')('connect:session-sequelize')
 const defaultOptions = {
   checkExpirationInterval: 15 * 60 * 1000, // The interval at which to cleanup expired sessions.
   expiration: 24 * 60 * 60 * 1000, // The maximum age (in milliseconds) of a valid session. Used when cookie.expires is not set.
-  disableTouch: false // When true, we will not update the db in the touch function call. Useful when you want more control over db writes.
+  disableTouch: false, // When true, we will not update the db in the touch function call. Useful when you want more control over db writes.
+  defaultModelKey : "Session",
+  defaultTableName : null
 }
 
 class SequelizeStoreException extends Error {
@@ -45,9 +47,11 @@ module.exports = function SequelizeSessionInit (Store) {
       } else {
         // No Table specified, default to ./model
         debug('No table specified, using default table.')
-        let modelKey = options.defaultModelKey || "Session" // Camelcase is the Standard-key. This should 
-        this.sessionModel = options.db.define(modelKey, defaultModel)
-        this.sessionModel.tableName = options.defaultTableName || modelKey
+        const modelKey = options.defaultModelKey || "Session"
+        this.sessionModel = options.db.define(modelKey, defaultModel, {
+          tableName : options.defaultTableName || modelKey
+        })
+
       }
     }
 

--- a/lib/connect-session-sequelize.js
+++ b/lib/connect-session-sequelize.js
@@ -5,7 +5,6 @@
  * License: MIT
  */
 
-const path = require('path')
 const Op = require('sequelize').Op || {}
 const defaultModel = require('./model')
 const debug = require('debug')('connect:session-sequelize')
@@ -13,8 +12,8 @@ const defaultOptions = {
   checkExpirationInterval: 15 * 60 * 1000, // The interval at which to cleanup expired sessions.
   expiration: 24 * 60 * 60 * 1000, // The maximum age (in milliseconds) of a valid session. Used when cookie.expires is not set.
   disableTouch: false, // When true, we will not update the db in the touch function call. Useful when you want more control over db writes.
-  defaultModelKey : "Session",
-  defaultTableName : null
+  modelKey: 'Session',
+  tableName: null
 }
 
 class SequelizeStoreException extends Error {
@@ -47,11 +46,10 @@ module.exports = function SequelizeSessionInit (Store) {
       } else {
         // No Table specified, default to ./model
         debug('No table specified, using default table.')
-        const modelKey = options.defaultModelKey || "Session"
+        const modelKey = options.modelKey || 'Session'
         this.sessionModel = options.db.define(modelKey, defaultModel, {
-          tableName : options.defaultTableName || modelKey
+          tableName: options.tableName || modelKey
         })
-
       }
     }
 

--- a/lib/connect-session-sequelize.js
+++ b/lib/connect-session-sequelize.js
@@ -45,8 +45,9 @@ module.exports = function SequelizeSessionInit (Store) {
       } else {
         // No Table specified, default to ./model
         debug('No table specified, using default table.')
-
-        this.sessionModel = options.db.define(options.defaultTableName || "Session", defaultModel)
+        let modelKey = options.defaultModelKey || "Session" // Camelcase is the Standard-key. This should 
+        this.sessionModel = options.db.define(modelKey, defaultModel)
+        this.sessionModel.tableName = options.defaultTableName || modelKey
       }
     }
 

--- a/lib/connect-session-sequelize.js
+++ b/lib/connect-session-sequelize.js
@@ -7,6 +7,7 @@
 
 const path = require('path')
 const Op = require('sequelize').Op || {}
+const defaultModel = require('./model')
 const debug = require('debug')('connect:session-sequelize')
 const defaultOptions = {
   checkExpirationInterval: 15 * 60 * 1000, // The interval at which to cleanup expired sessions.
@@ -44,7 +45,8 @@ module.exports = function SequelizeSessionInit (Store) {
       } else {
         // No Table specified, default to ./model
         debug('No table specified, using default table.')
-        this.sessionModel = options.db.import(path.join(__dirname, 'model'))
+
+        this.sessionModel = options.db.define(options.defaultTableName || "Session", defaultModel)
       }
     }
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -1,13 +1,13 @@
 /**
  * Session Model
  */
-module.exports = function (sequelize, DataTypes) {
-  return sequelize.define('Session', {
-    sid: {
-      type: DataTypes.STRING(36),
-      primaryKey: true
-    },
-    expires: DataTypes.DATE,
-    data: DataTypes.TEXT
-  })
-}
+  const DataTypes = require('sequelize').DataTypes
+
+ module.exports = {
+   sid: {
+     type: DataTypes.STRING(36),
+     primaryKey: true
+   },
+   expires: DataTypes.DATE,
+   data: DataTypes.TEXT
+ }

--- a/lib/model.js
+++ b/lib/model.js
@@ -1,13 +1,13 @@
 /**
  * Session Model
  */
-  const DataTypes = require('sequelize').DataTypes
+const DataTypes = require('sequelize').DataTypes
 
- module.exports = {
-   sid: {
-     type: DataTypes.STRING(36),
-     primaryKey: true
-   },
-   expires: DataTypes.DATE,
-   data: DataTypes.TEXT
- }
+module.exports = {
+  sid: {
+    type: DataTypes.STRING(36),
+    primaryKey: true
+  },
+  expires: DataTypes.DATE,
+  data: DataTypes.TEXT
+}


### PR DESCRIPTION
Hello, there was a little mistake in the description of tableName. Sorry for that! I fixed it.

previously

> * `tableName` *(optional)* a string for naming the generated table if `table` is not defined.
Default is the value of `defaultModelKey`.

now

> * `tableName` *(optional)* a string for naming the generated table if `table` is not defined.
Default is the value of `modelKey`.
