### PR TITLE
crypto: Support for OWASP session security recommendations

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ $ npm install connect-session-sequelize
 Default is the value of `modelKey`.
 * `extendDefaultFields` *(optional)* a way add custom data to table columns. Useful if using a custom model definition
 * `disableTouch` *(optional)* When true, the store will not update the db when receiving a touch() call. This can be useful in limiting db writes and introducing more manual control of session updates.
+* `secret` *(optional)* When true, the session is encrypted according to [OWASP sessions management](https://owasp.org/www-project-cheat-sheets/cheatsheets/Session_Management_Cheat_Sheet.html) recommendations.
 
 
 # Usage
@@ -141,6 +142,17 @@ var store = new SessionStore({
   db: sequelize,
   table: 'Session',
   extendDefaultFields: extendDefaultFields
+});
+```
+
+# Protect the session data
+
+To protect the session information, pass a `secret` option.
+
+```javascript
+var store = new SessionStore({
+  db: sequelize,
+  secret: 'squirrel'
 });
 ```
 

--- a/lib/connect-session-sequelize.js
+++ b/lib/connect-session-sequelize.js
@@ -33,6 +33,10 @@ module.exports = function SequelizeSessionInit (Store) {
         throw new SequelizeStoreException('Database connection is required')
       }
 
+      if (options.secret) {
+        options.kruptein = require('kruptein')(options)
+      }
+
       this.options = Object.assign(defaultOptions, this.options)
 
       this.startExpiringSessions()
@@ -58,6 +62,8 @@ module.exports = function SequelizeSessionInit (Store) {
     }
 
     get (sid, fn) {
+      let self = this
+
       debug('SELECT "%s"', sid)
       return this.sessionModel
         .findOne({ where: { sid: sid } })
@@ -68,6 +74,15 @@ module.exports = function SequelizeSessionInit (Store) {
           }
           debug('FOUND %s with data %s', session.sid, session.data)
 
+          if (self.options.secret) {
+            self.options.kruptein.get(self.options.secret, session.data, function (err, plaintext) {
+              if (err) return null
+
+              session.data = JSON.parse(plaintext)
+              debug('DECRYPT %s with data %s', session.sid, session.data)
+            })
+          }
+
           return JSON.parse(session.data)
         })
         .asCallback(fn)
@@ -75,8 +90,17 @@ module.exports = function SequelizeSessionInit (Store) {
 
     set (sid, data, fn) {
       debug('INSERT "%s"', sid)
-      const stringData = JSON.stringify(data)
+      let stringData = JSON.stringify(data)
       const expires = this.expiration(data)
+
+      if (this.options.secret) {
+        this.options.kruptein.set(this.options.secret, stringData, function (err, ciphertext) {
+          if (err) return
+
+          stringData = ciphertext
+          debug('ENCRYPT "%s"', sid)
+        })
+      }
 
       let defaults = { data: stringData, expires: expires }
       if (this.options.extendDefaultFields) {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   },
   "dependencies": {
     "debug": "^3.1.0",
-    "deep-equal": "^1.0.1"
+    "deep-equal": "^1.0.1",
+    "kruptein": "^2.0.5"
   },
   "devDependencies": {
     "express-session": "^1.10.3",


### PR DESCRIPTION
This will enable [OWASP sessions management](https://owasp.org/www-project-cheat-sheets/cheatsheets/Session_Management_Cheat_Sheet.html) recommendations for implementations that may push sensitive information to a server side session.