### PR TITLE
Allow sequelize v6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,10 @@
 
 language: node_js
 node_js:
-  - "11"
+  - "14"
+  - "12"
   - "10"
   - "8"
-  - "7"
-  - "6"
 sudo: false
 script:
   - npm run lint

--- a/lib/connect-session-sequelize.js
+++ b/lib/connect-session-sequelize.js
@@ -7,7 +7,6 @@
 
 const Op = require('sequelize').Op || {}
 const defaultModel = require('./model')
-const Promise = require('bluebird')
 const debug = require('debug')('connect:session-sequelize')
 const defaultOptions = {
   checkExpirationInterval: 15 * 60 * 1000, // The interval at which to cleanup expired sessions.
@@ -15,6 +14,23 @@ const defaultOptions = {
   disableTouch: false, // When true, we will not update the db in the touch function call. Useful when you want more control over db writes.
   modelKey: 'Session',
   tableName: 'Sessions'
+}
+
+function promisify (promise, fn) {
+  if (typeof fn === 'function') {
+    promise = promise.then(obj => {
+      fn(null, obj)
+    }).catch(err => {
+      if (!err) {
+        const error = new Error(err + '')
+        error.cause = err
+        err = error
+      }
+
+      fn(err)
+    })
+  }
+  return promise
 }
 
 class SequelizeStoreException extends Error {
@@ -60,18 +76,20 @@ module.exports = function SequelizeSessionInit (Store) {
 
     get (sid, fn) {
       debug('SELECT "%s"', sid)
-      return Promise.resolve(this.sessionModel
-        .findOne({ where: { sid: sid } }))
-        .then(function (session) {
-          if (!session) {
-            debug('Did not find session %s', sid)
-            return null
-          }
-          debug('FOUND %s with data %s', session.sid, session.data)
+      return promisify(
+        this.sessionModel
+          .findOne({ where: { sid: sid } })
+          .then(function (session) {
+            if (!session) {
+              debug('Did not find session %s', sid)
+              return null
+            }
+            debug('FOUND %s with data %s', session.sid, session.data)
 
-          return JSON.parse(session.data)
-        })
-        .asCallback(fn)
+            return JSON.parse(session.data)
+          }),
+        fn
+      )
     }
 
     set (sid, data, fn) {
@@ -84,35 +102,37 @@ module.exports = function SequelizeSessionInit (Store) {
         defaults = this.options.extendDefaultFields(defaults, data)
       }
 
-      return Promise.resolve(this.sessionModel
-        .findCreateFind({
-          where: { sid: sid },
-          defaults: defaults,
-          raw: false
-        }))
-        .spread(function sessionCreated (session) {
-          let changed = false
-          Object.keys(defaults).forEach(function (key) {
-            if (key === 'data') {
-              return
-            }
+      return promisify(
+        this.sessionModel
+          .findCreateFind({
+            where: { sid: sid },
+            defaults: defaults,
+            raw: false
+          })
+          .then(function sessionCreated ([session]) {
+            let changed = false
+            Object.keys(defaults).forEach(function (key) {
+              if (key === 'data') {
+                return
+              }
 
-            if (session.dataValues[key] !== defaults[key]) {
-              session[key] = defaults[key]
+              if (session.dataValues[key] !== defaults[key]) {
+                session[key] = defaults[key]
+                changed = true
+              }
+            })
+            if (session.data !== stringData) {
+              session.data = JSON.stringify(data)
               changed = true
             }
-          })
-          if (session.data !== stringData) {
-            session.data = JSON.stringify(data)
-            changed = true
-          }
-          if (changed) {
-            session.expires = expires
-            return Promise.resolve(session.save()).return(session)
-          }
-          return session
-        })
-        .asCallback(fn)
+            if (changed) {
+              session.expires = expires
+              return session.save().then(() => { return session })
+            }
+            return session
+          }),
+        fn
+      )
     }
 
     touch (sid, data, fn) {
@@ -125,38 +145,44 @@ module.exports = function SequelizeSessionInit (Store) {
 
       const expires = this.expiration(data)
 
-      return Promise.resolve(this.sessionModel
-        .update({ expires: expires }, { where: { sid: sid } }))
-        .then(function (rows) {
-          return rows
-        })
-        .asCallback(fn)
+      return promisify(
+        this.sessionModel
+          .update({ expires: expires }, { where: { sid: sid } })
+          .then(function (rows) {
+            return rows
+          }),
+        fn
+      )
     }
 
     destroy (sid, fn) {
       debug('DESTROYING %s', sid)
-      return Promise.resolve(this.sessionModel
-        .findOne({ where: { sid: sid }, raw: false }))
-        .then(function foundSession (session) {
-          // If the session wasn't found, then consider it destroyed already.
-          if (session === null) {
-            debug('Session not found, assuming destroyed %s', sid)
-            return null
-          }
-          return session.destroy()
-        })
-        .asCallback(fn)
+      return promisify(
+        this.sessionModel
+          .findOne({ where: { sid: sid }, raw: false })
+          .then(function foundSession (session) {
+            // If the session wasn't found, then consider it destroyed already.
+            if (session === null) {
+              debug('Session not found, assuming destroyed %s', sid)
+              return null
+            }
+            return session.destroy()
+          }),
+        fn
+      )
     }
 
     length (fn) {
-      return Promise.resolve(this.sessionModel.count()).asCallback(fn)
+      return promisify(this.sessionModel.count(), fn)
     }
 
     clearExpiredSessions (fn) {
       debug('CLEARING EXPIRED SESSIONS')
-      return Promise.resolve(this.sessionModel
-        .destroy({ where: { expires: { [Op.lt || 'lt']: new Date() } } }))
-        .asCallback(fn)
+      return promisify(
+        this.sessionModel
+          .destroy({ where: { expires: { [Op.lt || 'lt']: new Date() } } }),
+        fn
+      )
     }
 
     startExpiringSessions () {

--- a/lib/connect-session-sequelize.js
+++ b/lib/connect-session-sequelize.js
@@ -7,6 +7,7 @@
 
 const Op = require('sequelize').Op || {}
 const defaultModel = require('./model')
+const Promise = require('bluebird')
 const debug = require('debug')('connect:session-sequelize')
 const defaultOptions = {
   checkExpirationInterval: 15 * 60 * 1000, // The interval at which to cleanup expired sessions.
@@ -59,8 +60,8 @@ module.exports = function SequelizeSessionInit (Store) {
 
     get (sid, fn) {
       debug('SELECT "%s"', sid)
-      return this.sessionModel
-        .findOne({ where: { sid: sid } })
+      return Promise.resolve(this.sessionModel
+        .findOne({ where: { sid: sid } }))
         .then(function (session) {
           if (!session) {
             debug('Did not find session %s', sid)
@@ -83,12 +84,12 @@ module.exports = function SequelizeSessionInit (Store) {
         defaults = this.options.extendDefaultFields(defaults, data)
       }
 
-      return this.sessionModel
+      return Promise.resolve(this.sessionModel
         .findCreateFind({
           where: { sid: sid },
           defaults: defaults,
           raw: false
-        })
+        }))
         .spread(function sessionCreated (session) {
           let changed = false
           Object.keys(defaults).forEach(function (key) {
@@ -107,7 +108,7 @@ module.exports = function SequelizeSessionInit (Store) {
           }
           if (changed) {
             session.expires = expires
-            return session.save().return(session)
+            return Promise.resolve(session.save()).return(session)
           }
           return session
         })
@@ -124,8 +125,8 @@ module.exports = function SequelizeSessionInit (Store) {
 
       const expires = this.expiration(data)
 
-      return this.sessionModel
-        .update({ expires: expires }, { where: { sid: sid } })
+      return Promise.resolve(this.sessionModel
+        .update({ expires: expires }, { where: { sid: sid } }))
         .then(function (rows) {
           return rows
         })
@@ -134,8 +135,8 @@ module.exports = function SequelizeSessionInit (Store) {
 
     destroy (sid, fn) {
       debug('DESTROYING %s', sid)
-      return this.sessionModel
-        .findOne({ where: { sid: sid }, raw: false })
+      return Promise.resolve(this.sessionModel
+        .findOne({ where: { sid: sid }, raw: false }))
         .then(function foundSession (session) {
           // If the session wasn't found, then consider it destroyed already.
           if (session === null) {
@@ -148,13 +149,13 @@ module.exports = function SequelizeSessionInit (Store) {
     }
 
     length (fn) {
-      return this.sessionModel.count().asCallback(fn)
+      return Promise.resolve(this.sessionModel.count()).asCallback(fn)
     }
 
     clearExpiredSessions (fn) {
       debug('CLEARING EXPIRED SESSIONS')
-      return this.sessionModel
-        .destroy({ where: { expires: { [Op.lt || 'lt']: new Date() } } })
+      return Promise.resolve(this.sessionModel
+        .destroy({ where: { expires: { [Op.lt || 'lt']: new Date() } } }))
         .asCallback(fn)
     }
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "url": "https://github.com/mweibel/connect-session-sequelize.git"
   },
   "dependencies": {
-    "bluebird": "^3.7.2",
     "debug": "^3.1.0",
     "deep-equal": "^1.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "url": "https://github.com/mweibel/connect-session-sequelize.git"
   },
   "dependencies": {
+    "bluebird": "^3.7.2",
     "debug": "^3.1.0",
     "deep-equal": "^1.0.1"
   },

--- a/test/test.js
+++ b/test/test.js
@@ -1,15 +1,10 @@
 /* global describe,before,beforeEach,after,afterEach,it */
 
-var Promise = require('bluebird')
 var assert = require('assert')
 var session = require('express-session')
 var path = require('path')
 var SequelizeStore = require('../lib/connect-session-sequelize')(session.Store)
 var Sequelize = require('sequelize')
-
-Promise.config({
-  longStackTraces: true
-})
 
 var db = new Sequelize('session_test', 'test', '12345', {
   dialect: 'sqlite',

--- a/test/test.js
+++ b/test/test.js
@@ -6,8 +6,6 @@ var path = require('path')
 var SequelizeStore = require('../lib/connect-session-sequelize')(session.Store)
 var Sequelize = require('sequelize')
 
-Sequelize.Promise.longStackTraces()
-
 var db = new Sequelize('session_test', 'test', '12345', {
   operatorsAliases: false,
   dialect: 'sqlite',
@@ -41,7 +39,7 @@ describe('store db', function () {
   var db = {}
   beforeEach(function () {
     db = new Sequelize('session_test', 'test', '12345', { operatorsAliases: false, dialect: 'sqlite', logging: false })
-    db.import(path.join(__dirname, 'resources/model'))
+    require(path.join(__dirname, 'resources/model'))(db, Sequelize.DataTypes)
   })
 
   it('should take a specific table from Sequelize DB', function () {
@@ -122,7 +120,7 @@ describe('extendDefaultFields', function () {
     }
 
     db = new Sequelize('session_test', 'test', '12345', { operatorsAliases: false, dialect: 'sqlite', logging: console.log })
-    db.import(path.join(__dirname, 'resources/model'))
+    require(path.join(__dirname, 'resources/model'))(db, Sequelize.DataTypes)
     store = new SequelizeStore({ db: db, table: 'TestSession', extendDefaultFields: extend, checkExpirationInterval: -1 })
     return store.sync()
   })
@@ -281,7 +279,7 @@ describe('#stopExpiringSessions()', function () {
       '12345',
       { operatorsAliases: false, dialect: 'sqlite', logging: false }
     )
-    db.import(path.join(__dirname, 'resources/model'))
+    require(path.join(__dirname, 'resources/model'))(db, Sequelize.DataTypes)
     store = new SequelizeStore({
       db: db,
       table: 'TestSession',

--- a/test/test.js
+++ b/test/test.js
@@ -1,13 +1,17 @@
 /* global describe,before,beforeEach,after,afterEach,it */
 
+var Promise = require('bluebird')
 var assert = require('assert')
 var session = require('express-session')
 var path = require('path')
 var SequelizeStore = require('../lib/connect-session-sequelize')(session.Store)
 var Sequelize = require('sequelize')
 
+Promise.config({
+  longStackTraces: true
+})
+
 var db = new Sequelize('session_test', 'test', '12345', {
-  operatorsAliases: false,
   dialect: 'sqlite',
   logging: false
 })
@@ -38,7 +42,7 @@ describe('store', function () {
 describe('store db', function () {
   var db = {}
   beforeEach(function () {
-    db = new Sequelize('session_test', 'test', '12345', { operatorsAliases: false, dialect: 'sqlite', logging: false })
+    db = new Sequelize('session_test', 'test', '12345', { dialect: 'sqlite', logging: false })
     require(path.join(__dirname, 'resources/model'))(db, Sequelize.DataTypes)
   })
 
@@ -119,7 +123,7 @@ describe('extendDefaultFields', function () {
       return defaults
     }
 
-    db = new Sequelize('session_test', 'test', '12345', { operatorsAliases: false, dialect: 'sqlite', logging: console.log })
+    db = new Sequelize('session_test', 'test', '12345', { dialect: 'sqlite', logging: console.log })
     require(path.join(__dirname, 'resources/model'))(db, Sequelize.DataTypes)
     store = new SequelizeStore({ db: db, table: 'TestSession', extendDefaultFields: extend, checkExpirationInterval: -1 })
     return store.sync()
@@ -277,7 +281,7 @@ describe('#stopExpiringSessions()', function () {
       'session_test',
       'test',
       '12345',
-      { operatorsAliases: false, dialect: 'sqlite', logging: false }
+      { dialect: 'sqlite', logging: false }
     )
     require(path.join(__dirname, 'resources/model'))(db, Sequelize.DataTypes)
     store = new SequelizeStore({


### PR DESCRIPTION
- Wrap sequelize promises with bluebird since it was removed in Sequelize v6.
- removed calls to `sequelize.import` in tests 
- Sequelize v6 supports node 8+

fixes #105