### PR TITLE
Add in Bluebird promise support for Sequelize v6

### DIFF
--- a/lib/connect-session-sequelize.js
+++ b/lib/connect-session-sequelize.js
@@ -5,6 +5,7 @@
  * License: MIT
  */
 
+const Promise = require('bluebird')
 const Op = require('sequelize').Op || {}
 const defaultModel = require('./model')
 const debug = require('debug')('connect:session-sequelize')
@@ -59,7 +60,7 @@ module.exports = function SequelizeSessionInit (Store) {
 
     get (sid, fn) {
       debug('SELECT "%s"', sid)
-      return this.sessionModel
+      return Promise.resolve(this.sessionModel
         .findOne({ where: { sid: sid } })
         .then(function (session) {
           if (!session) {
@@ -69,7 +70,7 @@ module.exports = function SequelizeSessionInit (Store) {
           debug('FOUND %s with data %s', session.sid, session.data)
 
           return JSON.parse(session.data)
-        })
+        }))
         .asCallback(fn)
     }
 
@@ -83,12 +84,12 @@ module.exports = function SequelizeSessionInit (Store) {
         defaults = this.options.extendDefaultFields(defaults, data)
       }
 
-      return this.sessionModel
+      return Promise.resolve(this.sessionModel
         .findCreateFind({
           where: { sid: sid },
           defaults: defaults,
           raw: false
-        })
+        }))
         .spread(function sessionCreated (session) {
           let changed = false
           Object.keys(defaults).forEach(function (key) {
@@ -107,7 +108,7 @@ module.exports = function SequelizeSessionInit (Store) {
           }
           if (changed) {
             session.expires = expires
-            return session.save().return(session)
+            return Promise.resolve(session.save()).return(session)
           }
           return session
         })
@@ -124,17 +125,17 @@ module.exports = function SequelizeSessionInit (Store) {
 
       const expires = this.expiration(data)
 
-      return this.sessionModel
+      return Promise.resolve(this.sessionModel
         .update({ expires: expires }, { where: { sid: sid } })
         .then(function (rows) {
           return rows
-        })
+        }))
         .asCallback(fn)
     }
 
     destroy (sid, fn) {
       debug('DESTROYING %s', sid)
-      return this.sessionModel
+      return Promise.resolve(this.sessionModel
         .findOne({ where: { sid: sid }, raw: false })
         .then(function foundSession (session) {
           // If the session wasn't found, then consider it destroyed already.
@@ -143,18 +144,18 @@ module.exports = function SequelizeSessionInit (Store) {
             return null
           }
           return session.destroy()
-        })
+        }))
         .asCallback(fn)
     }
 
     length (fn) {
-      return this.sessionModel.count().asCallback(fn)
+      return Promise.resolve(this.sessionModel.count()).asCallback(fn)
     }
 
     clearExpiredSessions (fn) {
       debug('CLEARING EXPIRED SESSIONS')
-      return this.sessionModel
-        .destroy({ where: { expires: { [Op.lt || 'lt']: new Date() } } })
+      return Promise.resolve(this.sessionModel
+        .destroy({ where: { expires: { [Op.lt || 'lt']: new Date() } } }))
         .asCallback(fn)
     }
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "url": "https://github.com/mweibel/connect-session-sequelize.git"
   },
   "dependencies": {
+    "bluebird": "^3.7.2",
     "debug": "^3.1.0",
     "deep-equal": "^1.0.1"
   },

--- a/test/resources/model.js
+++ b/test/resources/model.js
@@ -1,14 +1,16 @@
+var Sequelize = require('sequelize')
+
 /*
  * Used to test custom table loading
  */
-module.exports = function (sequelize, DataTypes) {
+module.exports = function (sequelize) {
   return sequelize.define('TestSession', {
     sid: {
-      type: DataTypes.STRING,
+      type: Sequelize.DataTypes.STRING,
       primaryKey: true
     },
-    userId: DataTypes.STRING,
-    expires: DataTypes.DATE,
-    data: DataTypes.STRING(50000)
+    userId: Sequelize.DataTypes.STRING,
+    expires: Sequelize.DataTypes.DATE,
+    data: Sequelize.DataTypes.STRING(50000)
   })
 }

--- a/test/test.js
+++ b/test/test.js
@@ -1,15 +1,17 @@
 /* global describe,before,beforeEach,after,afterEach,it */
 
+var Promise = require('bluebird')
 var assert = require('assert')
 var session = require('express-session')
 var path = require('path')
 var SequelizeStore = require('../lib/connect-session-sequelize')(session.Store)
 var Sequelize = require('sequelize')
 
-Sequelize.Promise.longStackTraces()
+Promise.config({
+  longStackTraces: true
+})
 
 var db = new Sequelize('session_test', 'test', '12345', {
-  operatorsAliases: false,
   dialect: 'sqlite',
   logging: false
 })
@@ -39,9 +41,10 @@ describe('store', function () {
 
 describe('store db', function () {
   var db = {}
+
   beforeEach(function () {
-    db = new Sequelize('session_test', 'test', '12345', { operatorsAliases: false, dialect: 'sqlite', logging: false })
-    db.import(path.join(__dirname, 'resources/model'))
+    db = new Sequelize('session_test', 'test', '12345', { dialect: 'sqlite', logging: false })
+    db.models['TestSession'] = require(path.join(__dirname, 'resources/model'))(db)
   })
 
   it('should take a specific table from Sequelize DB', function () {
@@ -121,8 +124,8 @@ describe('extendDefaultFields', function () {
       return defaults
     }
 
-    db = new Sequelize('session_test', 'test', '12345', { operatorsAliases: false, dialect: 'sqlite', logging: console.log })
-    db.import(path.join(__dirname, 'resources/model'))
+    db = new Sequelize('session_test', 'test', '12345', { dialect: 'sqlite', logging: console.log })
+    db.models['TestSession'] = require(path.join(__dirname, 'resources/model'))(db)
     store = new SequelizeStore({ db: db, table: 'TestSession', extendDefaultFields: extend, checkExpirationInterval: -1 })
     return store.sync()
   })
@@ -279,9 +282,9 @@ describe('#stopExpiringSessions()', function () {
       'session_test',
       'test',
       '12345',
-      { operatorsAliases: false, dialect: 'sqlite', logging: false }
+      { dialect: 'sqlite', logging: false }
     )
-    db.import(path.join(__dirname, 'resources/model'))
+    db.models['TestSession'] = require(path.join(__dirname, 'resources/model'))(db)
     store = new SequelizeStore({
       db: db,
       table: 'TestSession',


### PR DESCRIPTION
Per https://sequelize.org/master/manual/upgrade-to-v6.html, Bluebird support for Sequelize was removed. This adds Bluebird as a new dependency to support compatibility with Sequelize v6.