### PR TITLE
Update connect-session-sequelize

### DIFF
--- a/lib/connect-session-sequelize.js
+++ b/lib/connect-session-sequelize.js
@@ -212,6 +212,25 @@ module.exports = function SequelizeSessionInit (Store) {
       }
       return new Date(Date.now() + this.options.expiration)
     }
+    
+       async ForcedUpdate(sid, Data) {
+
+            //Changes data for the new value in JSON
+            Data = JSON.stringify(Data)
+
+            //finds the session by Session ID
+            const ValueSession = await this.sessionModel.findOne({
+                where: {
+                    sid: sid
+                }
+            })
+
+            //changes value field data
+            ValueSession.data = Data
+
+            //saves changes
+            ValueSession.save()
+        }
   }
 
   return SequelizeStore


### PR DESCRIPTION
I added a function that allows to manually update the session, I did it because I was having some errors in relation to saving to the db after some change in the req.session

**example usage**:
```
//get the cookie and id
    let cookie = req.session.cookie //used in creation of data
    let id = req.session.id //used for search session

    //here's is defined the new field in data
    let newfield = 'Hi, i am a test'

    //here's is a object with data
    let data = {
        cookie,
        newfield

    }

    //call the function ForcedUpdate(r eq.session.id , {})
    Storage.ForcedUpdate(id, data)
```