### PR TITLE
Fix cookie.expires date assignment

### DIFF
--- a/lib/connect-session-sequelize.js
+++ b/lib/connect-session-sequelize.js
@@ -207,7 +207,7 @@ module.exports = function SequelizeSessionInit (Store) {
     }
 
     expiration (data) {
-      if (data.cookie && data.cookie.expires) {
+      if (data.cookie && data.cookie.expires && !isNaN(data.cookie.expires)) {
         return data.cookie.expires
       }
       return new Date(Date.now() + this.options.expiration)


### PR DESCRIPTION
I caught an error while creating a new session with this library. I tried downloading the code and log it to see what could be the cause, and it showed to me that the cookie generated here always had a **'Invalid Date'** value, resulting in a MySQL error after creating a new user or doing any other cookie or session validation.

Adding one more validation (`!NaN(data.cookie.expires)`) fixed this issue for me. Please, check if someone else have this problem and if this patch fixes it.