### PR TITLE
fix `SequelizeStoreOptions.table` type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -14,7 +14,7 @@ declare module 'connect-session-sequelize' {
 
   interface SequelizeStoreOptions {
     db: Sequelize;
-    table?: Model<any, any>;
+    table?: string;
     extendDefaultFields?: (defaults: DefaultFields, session: any) => Data;
     checkExpirationInterval?: number;
     expiration?: number;


### PR DESCRIPTION
its documented as string in README.md, in `connect-session-sequelize.js` its used as string