### PR TITLE
Type definition fixes

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -22,6 +22,7 @@ interface SequelizeStoreOptions {
 declare class SequelizeStore extends Store {
   sync(): void
   touch: (sid: string, data: any, callback?: (err: any) => void) => void
+  stopExpiringSessions: () => void
 }
 
 interface SequelizeStoreConstructor {

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,33 +1,33 @@
-declare module 'connect-session-sequelize' {
+import { Store } from 'express-session';
+import { Sequelize, Model } from 'sequelize';
 
-  import { Store } from 'express-session';
-  import { Sequelize, Model } from 'sequelize';
-
-  interface DefaultFields {
-    data: string;
-    expires: Date;
-  }
-
-  interface Data {
-    [column: string]: any;
-  }
-
-  interface SequelizeStoreOptions {
-    db: Sequelize;
-    table?: string;
-    extendDefaultFields?: (defaults: DefaultFields, session: any) => Data;
-    checkExpirationInterval?: number;
-    expiration?: number;
-  }
-
-  class SequelizeStore extends Store {
-    sync(): void
-    touch: (sid: string, data: any, callback?: (err: any) => void) => void
-  }
-
-  interface SequelizeStoreConstructor {
-    new(options: SequelizeStoreOptions): SequelizeStore;
-  }
-
-  export default function init(store: typeof Store): SequelizeStoreConstructor;
+interface DefaultFields {
+  data: string;
+  expires: Date;
 }
+
+interface Data {
+  [column: string]: any;
+}
+
+interface SequelizeStoreOptions {
+  db: Sequelize;
+  table?: string;
+  extendDefaultFields?: (defaults: DefaultFields, session: any) => Data;
+  checkExpirationInterval?: number;
+  expiration?: number;
+}
+
+declare class SequelizeStore extends Store {
+  sync(): void
+  touch: (sid: string, data: any, callback?: (err: any) => void) => void
+}
+
+interface SequelizeStoreConstructor {
+  new(options: SequelizeStoreOptions): SequelizeStore;
+}
+
+declare namespace init {}
+declare function init(store: typeof Store): SequelizeStoreConstructor;
+
+export = init;

--- a/index.d.ts
+++ b/index.d.ts
@@ -13,6 +13,7 @@ interface Data {
 interface SequelizeStoreOptions {
   db: Sequelize;
   table?: string;
+  tableName?: string;
   extendDefaultFields?: (defaults: DefaultFields, session: any) => Data;
   checkExpirationInterval?: number;
   expiration?: number;


### PR DESCRIPTION
I was having issues importing this library with TS so I started looking at the index.d.ts. I don't have a lot of experience with TS, so I might be wrong, but looking at the docs [here](https://www.typescriptlang.org/docs/handbook/declaration-files/templates/module-d-ts.html) it seems that `export default ` only works if the project has the config ` esModuleInterop: true`, and mentions `export =  ` should work everywhere (and i also had to add the `declare namespace init {} ` to make it work).

It also looks like `declare module 'connect-session-sequelize' { ` is only used when declaring types for another library from your own project, so maybe is not necessary here?

Finally, I added the `tableName?: string; ` option, since it looked like it was missing (happy to open another PR for this if you guys think it would be better)

Thanks!


EDIT: also added `stopExpiringSessions` to the type definition