### PR TITLE
Made it possible to use JSON fields for data in the database

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -17,11 +17,12 @@ interface SequelizeStoreOptions {
   extendDefaultFields?: (defaults: DefaultFields, session: any) => Data;
   checkExpirationInterval?: number;
   expiration?: number;
+  isDataFieldText?: boolean;
 }
 
 declare class SequelizeStore extends Store {
   sync(): void
-  touch: (sid: string, data: any, callback?: (err: any) => void) => void
+  touch: (sid: string, data: any, callback?: (err: any) => void) => void;
   stopExpiringSessions: () => void
 }
 

--- a/lib/connect-session-sequelize.js
+++ b/lib/connect-session-sequelize.js
@@ -6,14 +6,16 @@
  */
 
 const Op = require('sequelize').Op || {}
-const defaultModel = require('./model')
+const modelText = require('./model')
+const modelJson = require('./modelJson')
 const debug = require('debug')('connect:session-sequelize')
 const defaultOptions = {
   checkExpirationInterval: 15 * 60 * 1000, // The interval at which to cleanup expired sessions.
   expiration: 24 * 60 * 60 * 1000, // The maximum age (in milliseconds) of a valid session. Used when cookie.expires is not set.
   disableTouch: false, // When true, we will not update the db in the touch function call. Useful when you want more control over db writes.
   modelKey: 'Session',
-  tableName: 'Sessions'
+  tableName: 'Sessions',
+  isDataFieldText: true
 }
 
 function promisify (promise, fn) {
@@ -64,6 +66,7 @@ module.exports = function SequelizeSessionInit (Store) {
         // No Table specified, default to ./model
         debug('No table specified, using default table.')
         const modelKey = options.modelKey || 'Session'
+        const defaultModel = options.isDataFieldText? modelText : modelJson;
         this.sessionModel = options.db.define(modelKey, defaultModel, {
           tableName: options.tableName || modelKey
         })
@@ -79,14 +82,14 @@ module.exports = function SequelizeSessionInit (Store) {
       return promisify(
         this.sessionModel
           .findOne({ where: { sid: sid } })
-          .then(function (session) {
+          .then((session) => {
             if (!session) {
               debug('Did not find session %s', sid)
               return null
             }
             debug('FOUND %s with data %s', session.sid, session.data)
 
-            return JSON.parse(session.data)
+            return this.reverseConvertData(session.data)
           }),
         fn
       )
@@ -94,10 +97,10 @@ module.exports = function SequelizeSessionInit (Store) {
 
     set (sid, data, fn) {
       debug('INSERT "%s"', sid)
-      const stringData = JSON.stringify(data)
+      const convertedData = this.convertData(data);
       const expires = this.expiration(data)
 
-      let defaults = { data: stringData, expires: expires }
+      let defaults = { data: convertedData, expires: expires }
       if (this.options.extendDefaultFields) {
         defaults = this.options.extendDefaultFields(defaults, data)
       }
@@ -109,7 +112,7 @@ module.exports = function SequelizeSessionInit (Store) {
             defaults: defaults,
             raw: false
           })
-          .then(function sessionCreated ([session]) {
+          .then(([session]) => {
             let changed = false
             Object.keys(defaults).forEach(function (key) {
               if (key === 'data') {
@@ -121,8 +124,8 @@ module.exports = function SequelizeSessionInit (Store) {
                 changed = true
               }
             })
-            if (session.data !== stringData) {
-              session.data = JSON.stringify(data)
+            if (session.data !== convertedData) {
+              session.data = this.convertData(data)
               changed = true
             }
             if (changed) {
@@ -212,6 +215,14 @@ module.exports = function SequelizeSessionInit (Store) {
       }
       return new Date(Date.now() + this.options.expiration)
     }
+
+    convertData(data) {
+      return this.options.isDataFieldText? JSON.stringify(data) : data;
+    }
+    reverseConvertData(data) {
+      return this.options.isDataFieldText? JSON.parse(data) : data;
+    }
+
   }
 
   return SequelizeStore

--- a/lib/modelJson.js
+++ b/lib/modelJson.js
@@ -1,0 +1,13 @@
+/**
+ * Session Model with JSON data field
+ */
+const DataTypes = require('sequelize').DataTypes
+
+module.exports = {
+  sid: {
+    type: DataTypes.STRING(36),
+    primaryKey: true
+  },
+  expires: DataTypes.DATE,
+  data: DataTypes.JSON
+}


### PR DESCRIPTION
Changes have been made to implement the ability to use JSON fields to store data in the database. It also solves the problem of converting data when saving and reading, and also preserves the original data types (the number does not become a string)

I made for this:
created a model with JSON data field

created option isDataFieldText in SequelizeStoreOptions, for connect model with JSON data field;
new model has been connected

created converting and reverse converting session data to string or to JSON