### PR TITLE
Add options to sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,7 @@ app.use(
 );
 // continue as normal
 ```
-
-If you want SequelizeStore to create/sync the database table for you, you can call `sync()` against an instance of `SequelizeStore` - this will run a sequelize `sync()` operation on the model for an initialized SequelizeStore object:
+If you want SequelizeStore to create/sync the database table for you, you can call `sync()` against an instance of `SequelizeStore` along with [options](https://sequelize.org/master/class/lib/model.js~Model.html#static-method-sync) if needed. This will run a sequelize `sync()` operation on the model for an initialized SequelizeStore object :
 
 ```javascript
 var myStore = new SequelizeStore({

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 import { Store } from 'express-session';
-import { Sequelize, Model } from 'sequelize';
+import { Sequelize, SyncOptions } from 'sequelize';
 
 interface DefaultFields {
   data: string;
@@ -20,7 +20,7 @@ interface SequelizeStoreOptions {
 }
 
 declare class SequelizeStore extends Store {
-  sync(): void
+  sync(options?: SyncOptions): void
   touch: (sid: string, data: any, callback?: (err: any) => void) => void
   stopExpiringSessions: () => void
 }

--- a/lib/connect-session-sequelize.js
+++ b/lib/connect-session-sequelize.js
@@ -70,8 +70,8 @@ module.exports = function SequelizeSessionInit (Store) {
       }
     }
 
-    sync () {
-      return this.sessionModel.sync()
+    sync (options) {
+      return this.sessionModel.sync(options)
     }
 
     get (sid, fn) {


### PR DESCRIPTION
Sequelize sync model function can take options as argument.
We can use options also while using connect-session-sequelize