### PR TITLE
Fix, simplify & test default options lookup

### DIFF
--- a/lib/connect-session-sequelize.js
+++ b/lib/connect-session-sequelize.js
@@ -44,28 +44,25 @@ module.exports = function SequelizeSessionInit (Store) {
   class SequelizeStore extends Store {
     constructor (options) {
       super(options)
-      this.options = options = options || {}
+      this.options = { ...defaultOptions, ...(options || {}) }
 
-      if (!options.db) {
+      if (!this.options.db) {
         throw new SequelizeStoreException('Database connection is required')
       }
-
-      this.options = Object.assign(defaultOptions, this.options)
 
       this.startExpiringSessions()
 
       // Check if specific table should be used for DB connection
-      if (options.table) {
-        debug('Using table: %s for sessions', options.table)
+      if (this.options.table) {
+        debug('Using table: %s for sessions', this.options.table)
         // Get Specifed Table from Sequelize Object
         this.sessionModel =
-          options.db[options.table] || options.db.models[options.table]
+          this.options.db[this.options.table] || this.options.db.models[this.options.table]
       } else {
         // No Table specified, default to ./model
         debug('No table specified, using default table.')
-        const modelKey = options.modelKey || 'Session'
-        this.sessionModel = options.db.define(modelKey, defaultModel, {
-          tableName: options.tableName || modelKey
+        this.sessionModel = this.options.db.define(this.options.modelKey, defaultModel, {
+          tableName: this.options.tableName || this.options.modelKey
         })
       }
     }

--- a/test/test.js
+++ b/test/test.js
@@ -51,6 +51,32 @@ describe('store db', function () {
     var store = new SequelizeStore({ db: db, checkExpirationInterval: -1 })
     assert.strictEqual(store.sessionModel.name, 'Session')
   })
+
+  it('should use the default model key if not specified in options', function () {
+    var store = new SequelizeStore({ db: db, checkExpirationInterval: -1 })
+    assert.strictEqual(store.sessionModel.name, 'Session')
+  })
+
+  it('should use an explicit model key', function () {
+    var store = new SequelizeStore({ db: db, modelKey: 'CustomSessionModel', checkExpirationInterval: -1 })
+    assert.strictEqual(store.sessionModel.name, 'CustomSessionModel')
+  })
+
+  it('should use the default table name if not specified in options', function () {
+    var store = new SequelizeStore({ db: db, checkExpirationInterval: -1 })
+    assert.strictEqual(store.sessionModel.tableName, 'Sessions')
+  })
+
+  it('should use an explicit table name', function () {
+    var store = new SequelizeStore({ db: db, tableName: 'CustomSessionsTable', checkExpirationInterval: -1 })
+    assert.strictEqual(store.sessionModel.tableName, 'CustomSessionsTable')
+  })
+
+  it('should use explicit model/table options', function () {
+    var store = new SequelizeStore({ db: db, modelKey: 'CustomSessionModel', tableName: 'CustomSessionsTable', checkExpirationInterval: -1 })
+    assert.strictEqual(store.sessionModel.name, 'CustomSessionModel')
+    assert.strictEqual(store.sessionModel.tableName, 'CustomSessionsTable')
+  })
 })
 
 describe('#set()', function () {


### PR DESCRIPTION
With #97, the default option for `tableName` was set as `Sessions`.  However, given the previous logic for resolving options provided, the default was never utilised (`options.tableName` was used, which never [considered](https://github.com/mweibel/connect-session-sequelize/blob/394645289e17c2e962fe6650729b3f0e691a3134/lib/connect-session-sequelize.js#L68) the `defaultOptions` object). This was discovered on a database with no `CREATE` privileges where it tried to create a table called `Session`; this database had a pre-existing `Sessions` table that was created with an older version of `connect-session-sequelize`:

```sql
  sequelize:sql:mssql Executing (default): IF OBJECT_ID('[Session]', 'U') IS NULL CREATE TABLE [Session] ([sid] NVARCHAR(36) , [expires] DATETIMEOFFSET NULL, [data] NVARCHAR(MAX) NULL, [createdAt] DATETIMEOFFSET NOT NULL, [updatedAt] DATETIMEOFFSET NOT NULL, PRIMARY KEY ([sid]));
  sequelize:pool connection released +147ms
  webapp:error SequelizeDatabaseError: CREATE TABLE permission denied in database 'webservice'.
```

This change simplifies and cleans up the options lookup process, canonically using `this.options` for all options, ensuring `defaultOptions` is introduced during construction of the SequelizeStore.

Additionally, this change fixes a subtle bug - the previous use of the `Object.assign` function had the side effect of modifying the first argument provided, which was the `defaultOptions` object. This would have impacted subsequent session stores as the defaults were accidentally modified by the first session store.  The impact of this is isolated since an app with only 1 store wouldn't be affected and the original constructor didn't actually use the defaults (see above).

This change adds various additional tests to ensure the option resolution succeeds.

----

For note, to work around this issue (e.g. needing to use `Sessions` as the `tableName`), it's possible to specify these options explicitly when setting up the session store, such as:
```js
const session = require('express-session')
const SequelizeStore = require('connect-session-sequelize')(session.Store)
SequelizeStore({ db, tableName: 'Sessions' })
```