### PR TITLE
Remove unused dependency: `deep-equal`

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,7 @@
     "url": "https://github.com/mweibel/connect-session-sequelize.git"
   },
   "dependencies": {
-    "debug": "^4.1.1",
-    "deep-equal": "^2.0.3"
+    "debug": "^4.1.1"
   },
   "devDependencies": {
     "express-session": "^1.17.1",


### PR DESCRIPTION
Aside `assert.deepEqual()` being native and faster, this dependency just
isn’t being used. I did _not_ regenerate the `package-lock.json` though
because it seems there are dependabot and an `npm audit` error that
should be addressed—along with the version of package ≠ version in the
lockfile—so I thought that part would be best left to the maintainer.