### PR TITLE
fix/findCreateFind should always use master

### DIFF
--- a/lib/connect-session-sequelize.js
+++ b/lib/connect-session-sequelize.js
@@ -104,7 +104,8 @@ module.exports = function SequelizeSessionInit (Store) {
           .findCreateFind({
             where: { sid: sid },
             defaults: defaults,
-            raw: false
+            raw: false,
+            useMaster: true,
           })
           .then(function sessionCreated ([session]) {
             let changed = false

--- a/lib/connect-session-sequelize.js
+++ b/lib/connect-session-sequelize.js
@@ -105,7 +105,7 @@ module.exports = function SequelizeSessionInit (Store) {
             where: { sid: sid },
             defaults: defaults,
             raw: false,
-            useMaster: true,
+            useMaster: true
           })
           .then(function sessionCreated ([session]) {
             let changed = false


### PR DESCRIPTION
First obligatory thank you for this projet, we have been using it in production for more than 3 years.


When using sequelize with read replica instance we can race condition on the findCreateFind query.

I just starting testing the read replica configuration and encountered the following bug when creating a session :
```Cannot read properties of null (reading 'dataValues')```
This can happen because while the session was written in the master db the following find query is made in the read replica which is not updated yet due to latency.

Adding ``` useMaster: true``` option to the findCreateFind query should force the find query to be made against the master db thus avoiding the bug.
More information on sequelize read replication : https://sequelize.org/docs/v6/other-topics/read-replication/

I am not able to replicate the issue with the exemple repository since it requires a specific database setup. If you need more information I would be happy to help.