### PR TITLE
TS return type of the sync() method changed to promise

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -21,7 +21,7 @@ interface SequelizeStoreOptions {
 }
 
 declare class SequelizeStore extends Store {
-  sync(options?: SyncOptions): void
+  sync(options?: SyncOptions): Promise<unknown>
   touch: (sid: string, data: any, callback?: (err: any) => void) => void
   stopExpiringSessions: () => void
   get(sid: string, callback: (err: any, session?: SessionData | null) => void): void


### PR DESCRIPTION
See #152 for more info. I used "unknown" since I do not think I'll need to export the whole model to the user. 

Another possible solution more in line with the rest of the code base would probably be a callback that is called once the promise returns. That would be a code change, not just a change of the description file, though.
