### PR TITLE
Support table name being different than model key

### DIFF
--- a/lib/connect-session-sequelize.js
+++ b/lib/connect-session-sequelize.js
@@ -57,7 +57,7 @@ module.exports = function SequelizeSessionInit (Store) {
         debug('Using table: %s for sessions', this.options.table)
         // Get Specifed Table from Sequelize Object
         this.sessionModel =
-          this.options.db[this.options.table] || this.options.db.models[this.options.table]
+          this.options.db.models[this.options.modelKey] || this.options.db[this.options.table] || this.options.db.models[this.options.table]
       } else {
         // No Table specified, default to ./model
         debug('No table specified, using default table.')


### PR DESCRIPTION
In Sequelize, the model key/class name can be different than the table name.

```js

export default class SessionModel extends Model {
	declare sid: string;
	declare expires: Date;
	declare data: string;

	static initModel(sequelize: Sequelize) {
		SessionModel.init({
			sid: { type: DataTypes.STRING, primaryKey: true },
			expires: { type: DataTypes.DATE },
			data: { type: DataTypes.TEXT },
		}, {
			sequelize,
			tableName: "session"
		});
	};
};
```

Here, the model name is `SessionModel` and the table name is `session`.

Currently, connect-session-sequelize assumes that the custom model name is the same as the custom table name. This PR adds support for using a different model key than table name.