### PR TITLE
Fix out of sync Session Table in Read replica

### DIFF
--- a/lib/connect-session-sequelize.js
+++ b/lib/connect-session-sequelize.js
@@ -75,7 +75,7 @@ module.exports = function SequelizeSessionInit (Store) {
       debug('SELECT "%s"', sid)
       return promisify(
         this.sessionModel
-          .findOne({ where: { sid: sid } })
+          .findOne({ where: { sid: sid }, useMaster: true })
           .then(function (session) {
             if (!session) {
               debug('Did not find session %s', sid)


### PR DESCRIPTION
### Issue

- In using sequelize and postgres with read replica as the database. The query of session by sessionId sometimes would be empty. 
- The cause was that the Read replica is not up to date with the master. Sequelize would used the read replica on read queries as default. 

### Fix
- The change was implemented by adding the `useMaster: true` option to the database query. This ensures that the most up-to-date data is being used

There is also a similar merged PR related to using read replica https://github.com/mweibel/connect-session-sequelize/pull/145

I was not able to replicate the fix in https://github.com/mweibel/connect-session-sequelize-example because my setup is on postgres. However when testing on my application, the query would now be always on the Master Database