### PR TITLE
Adding an additional check to ensure a `db.models` object exists prior to checking for the existence of a table in that object.

### DIFF
--- a/lib/connect-session-sequelize.js
+++ b/lib/connect-session-sequelize.js
@@ -61,7 +61,7 @@ module.exports = function SequelizeSessionInit (Store) {
           this.sessionModel = this.options.db[this.options.modelKey] || this.options.db[this.options.table]
         } else {
           // If db.models is defined, use the model from the models object
-          this.options.db.models[this.options.modelKey] || this.options.db.models[this.options.table]
+          this.sessionModel = this.options.db.models[this.options.modelKey] || this.options.db.models[this.options.table]
         }
       } else {
         // No Table specified, default to ./model


### PR DESCRIPTION
- Adding an additional check to ensure a `db.models` object exists prior to checking for the existence of a table in that object.
- If the `db.models` object does not exist it will try to leverage the `this.options.modelKey` prior to the `this.options.table`.
- **NOTE:** I am only doing it this way to maintain the logical flow that already existed while preventing the library from throwing if the key `models` does not exist on the database.