### PR TITLE
Update link to Sequelize website in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Node.js CI](https://github.com/mweibel/connect-session-sequelize/actions/workflows/node.js.yml/badge.svg)](https://github.com/mweibel/connect-session-sequelize/actions/workflows/node.js.yml)
 
-connect-session-sequelize is a SQL session store using [Sequelize.js](http://sequelizejs.com).
+connect-session-sequelize is a SQL session store using [Sequelize.js](https://sequelize.org/).
 
 # Installation
 


### PR DESCRIPTION
The sequelizejs.com website redirects to sequelize.org, but with a small mistake (`https://sequelize.org/*`, https://github.com/sequelize/website/issues/839). This PR changes the link to point directly to the new website (and adds explicit `https://`).